### PR TITLE
EF-76: Flow EF metadata down through CreateGetValueExpression

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -184,8 +184,8 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
             {
                 if (parameterExpression.Type == typeof(BsonDocument) || parameterExpression.Type == typeof(BsonArray))
                 {
+                    // "alias" will be different from the property/navigation name when mapped to a different name in the document.
                     string? alias = null;
-                    var fieldRequired = true;
                     IPropertyBase? propertyBase = null;
 
                     var projectionExpression = ((UnaryExpression)binaryExpression.Right).Operand;
@@ -222,7 +222,6 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                                 innerAccessExpression = innerObjectAccessExpression.AccessExpression;
                                 _ownerMappings[accessExpression] =
                                     (innerObjectAccessExpression.Navigation.DeclaringEntityType, innerAccessExpression);
-                                fieldRequired = innerObjectAccessExpression.Required;
                                 propertyBase = innerObjectAccessExpression.Navigation;
                                 break;
                             case RootReferenceExpression:
@@ -400,6 +399,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     /// </summary>
     /// <param name="documentExpression">The <see cref="Expression"/> used to access the <see cref="BsonDocument"/>.</param>
     /// <param name="alias">The name of the property.</param>
+    /// <param name="propertyBase">The <see cref="INavigation"/> or <see cref="IProperty"/> associated with the value.</param>
     /// <returns>A compilable <see cref="Expression"/> to obtain the desired value as the correct type.</returns>
     private Expression CreateGetValueExpression(
         Expression documentExpression,

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -90,8 +90,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         var shaperBody = shapedQueryExpression.ShaperExpression;
         shaperBody = new BsonDocumentInjectingExpressionVisitor().Visit(shaperBody);
         shaperBody = InjectEntityMaterializers(shaperBody);
-        shaperBody = new MongoProjectionBindingRemovingExpressionVisitor(
-                rootEntityType, mongoQueryExpression, bsonDocParameter, trackQueryResults)
+        shaperBody = new MongoProjectionBindingRemovingExpressionVisitor(mongoQueryExpression, bsonDocParameter, trackQueryResults)
             .Visit(shaperBody);
 
         var shaperLambda = Expression.Lambda(

--- a/src/MongoDB.EntityFrameworkCore/Serializers/BsonSerializerFactory.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/BsonSerializerFactory.cs
@@ -282,7 +282,7 @@ public sealed class BsonSerializerFactory
         return CreateGenericSerializer(typeof(EnumerableInterfaceImplementerSerializer<,>), [type, itemType], childSerializer);
     }
 
-    internal static BsonSerializationInfo GetPropertySerializationInfo(IReadOnlyProperty property)
+    internal static BsonSerializationInfo GetPropertySerializationInfo(string? alias, IReadOnlyProperty property)
     {
         var serializer = CreateTypeSerializer(property);
 
@@ -298,12 +298,12 @@ public sealed class BsonSerializerFactory
         if (binaryVectorType != null)
         {
             return new BsonSerializationInfo(
-                property.GetElementName(),
+                alias ?? property.GetElementName(),
                 CreateBinaryVectorSerializer(type, binaryVectorType.Value),
                 serializer.ValueType);
         }
 
-        return new BsonSerializationInfo(property.GetElementName(), serializer, serializer.ValueType);
+        return new BsonSerializationInfo(alias ?? property.GetElementName(), serializer, serializer.ValueType);
     }
 
     private static IBsonSerializer CreateBinaryVectorSerializer(Type type, BinaryVectorDataType binaryVectorDataType)

--- a/src/MongoDB.EntityFrameworkCore/Serializers/EntitySerializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/EntitySerializer.cs
@@ -98,7 +98,7 @@ internal class EntitySerializer<TValue> :
         var property = _entityType.FindProperty(memberName);
         if (property != null)
         {
-            serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(property);
+            serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(null, property);
             return true;
         }
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
@@ -17,11 +17,10 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
-using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Serializers;
 
 namespace MongoDB.EntityFrameworkCore.Storage;
@@ -34,60 +33,37 @@ internal static class BsonBinding
     /// <summary>
     /// Create the expression which will obtain the value or intermediate value required by the shaper.
     /// </summary>
-    /// <param name="bsonDocExpression">The expression to obtain the current <see cref="BsonDocument"/>.</param>
-    /// <param name="name">The name of the field in the document that contains the desired value.</param>
-    /// <param name="required">
-    /// <see langword="true"/> if the field is required to be present in the document,
-    /// <see langword="false"/> if it is optional.
-    /// </param>
-    /// <param name="mappedType">What <see cref="Type"/> to the value is to be treated as.</param>
-    /// <param name="declaredType">The <see cref="ITypeBase"/> the value will belong to in order to obtaining additional metadata.</param>
+    /// <param name="documentExpression">The expression to obtain the current <see cref="BsonDocument"/>.</param>
+    /// <param name="alias">The name of the field in the document that contains the desired value.</param>
+    /// <param name="propertyBase">The <see cref="INavigation"/> or <see cref="IProperty"/> mapping to the field.</param>
     /// <returns>A compilable expression the shaper can use to obtain this value from a <see cref="BsonDocument"/>.</returns>
     /// <exception cref="InvalidOperationException">If we can't find anything mapped to this name.</exception>
     public static Expression CreateGetValueExpression(
-        Expression bsonDocExpression,
-        string? name,
-        bool required,
-        Type mappedType,
-        ITypeBase declaredType)
+        Expression documentExpression,
+        string? alias,
+        IPropertyBase? propertyBase = null)
     {
-        if (name is null)
+        if (propertyBase is null && alias is null)
         {
-            return bsonDocExpression;
+            return documentExpression;
         }
 
-        if (mappedType == typeof(BsonArray))
+        if (propertyBase is IProperty property)
         {
-            return CreateGetBsonArray(bsonDocExpression, name);
+            return CreateGetPropertyValue(documentExpression, alias, property);
         }
 
-        if (mappedType == typeof(BsonDocument))
-        {
-            return CreateGetBsonDocument(bsonDocExpression, name, required, declaredType);
-        }
-
-        var targetProperty = declaredType.FindProperty(name);
-        if (targetProperty != null)
-        {
-            return CreateGetPropertyValue(bsonDocExpression, Expression.Constant(targetProperty),
-                targetProperty.IsNullable ? mappedType.MakeNullable() : mappedType);
-        }
-
-        if (declaredType is IEntityType entityType)
-        {
-            var navigationProperty = entityType.FindNavigation(name);
-            if (navigationProperty != null)
-            {
-                var fieldName = navigationProperty.TargetEntityType.GetContainingElementName()!;
-                return CreateGetElementValue(bsonDocExpression, fieldName, mappedType);
-            }
-        }
-
-        throw new InvalidOperationException(CoreStrings.PropertyNotFound(name, declaredType.DisplayName()));
+        var navigation = (INavigation)propertyBase!;
+        return navigation.IsCollection
+            ? CreateGetBsonArray(documentExpression, alias, navigation)
+            : CreateGetBsonDocument(documentExpression, alias, navigation);
     }
 
-    private static MethodCallExpression CreateGetBsonArray(Expression bsonDocExpression, string name)
-        => Expression.Call(null, GetBsonArrayMethodInfo, bsonDocExpression, Expression.Constant(name));
+    private static MethodCallExpression CreateGetBsonArray(Expression documentExpression, string? alias, INavigation navigation)
+        => Expression.Call(
+            GetBsonArrayMethodInfo,
+            documentExpression,
+            Expression.Constant(alias ?? navigation.Name, typeof(string)));
 
     private static readonly MethodInfo GetBsonArrayMethodInfo
         = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
@@ -107,10 +83,10 @@ internal static class BsonBinding
     }
 
     private static MethodCallExpression CreateGetBsonDocument(
-        Expression bsonDocExpression, string name, bool required, ITypeBase declaredType)
-        => Expression.Call(null, GetBsonDocumentMethodInfo, bsonDocExpression, Expression.Constant(name),
-            Expression.Constant(required),
-            Expression.Constant(declaredType));
+        Expression documentExpression, string? alias, INavigation navigation)
+        => Expression.Call(null, GetBsonDocumentMethodInfo, documentExpression, Expression.Constant(alias ?? navigation.Name),
+            Expression.Constant(navigation.ForeignKey.IsRequiredDependent),
+            Expression.Constant(navigation.DeclaringEntityType));
 
     private static readonly MethodInfo GetBsonDocumentMethodInfo
         = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
@@ -129,23 +105,20 @@ internal static class BsonBinding
     }
 
     private static MethodCallExpression
-        CreateGetPropertyValue(Expression bsonDocExpression, Expression propertyExpression, Type resultType) =>
-        Expression.Call(null, GetPropertyValueMethodInfo.MakeGenericMethod(resultType), bsonDocExpression, propertyExpression);
-
-    private static MethodCallExpression CreateGetElementValue(Expression bsonDocExpression, string name, Type type) =>
-        Expression.Call(null, GetElementValueMethodInfo.MakeGenericMethod(type), bsonDocExpression, Expression.Constant(name));
+        CreateGetPropertyValue(Expression documentExpression, string? alias, IProperty property)
+        => Expression.Call(
+            GetPropertyValueMethodInfo.MakeGenericMethod(property.IsNullable ? property.ClrType.MakeNullable() : property.ClrType),
+            documentExpression,
+            Expression.Constant(alias ?? property.GetElementName(), typeof(string)),
+            Expression.Constant(property));
 
     private static readonly MethodInfo GetPropertyValueMethodInfo
         = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
             .Single(mi => mi.Name == nameof(GetPropertyValue));
 
-    private static readonly MethodInfo GetElementValueMethodInfo
-        = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
-            .Single(mi => mi.Name == nameof(GetElementValue));
-
-    internal static T? GetPropertyValue<T>(BsonDocument document, IReadOnlyProperty property)
+    internal static T? GetPropertyValue<T>(BsonDocument document, string? alias, IReadOnlyProperty property)
     {
-        var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(property);
+        var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(alias, property);
         if (TryReadElementValue(document, serializationInfo, out T? value))
         {
             if (value == null && !property.IsNullable)
@@ -159,7 +132,7 @@ internal static class BsonBinding
 
         if (property.IsNullable) return default;
 
-        throw new InvalidOperationException($"Document element is missing for required non-nullable property '{property.Name}'.");
+        throw new InvalidOperationException($"Document element is missing for required non-nullable property '{alias ?? property.Name}'.");
     }
 
     internal static T? GetElementValue<T>(BsonDocument document, string elementName)

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
@@ -203,7 +203,7 @@ internal class MongoUpdate(IUpdateEntry entry, WriteModel<BsonDocument> model)
 
     private static void WriteProperty(IBsonWriter writer, object? value, IProperty property)
     {
-        var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(property);
+        var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(null, property);
         writer.WriteName(serializationInfo.ElementPath?.Last() ?? serializationInfo.ElementName);
         var root = BsonSerializationContext.CreateRoot(writer);
         serializationInfo.Serializer.Serialize(root, value);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -2384,43 +2384,46 @@ Orders.{ "$match" : { "$and" : [{ "OrderDate" : { "$ne" : null } }, { "$expr" : 
 
     public override async Task Select_expression_long_to_string(bool async)
     {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_long_to_string(async))).Message);
+        await base.Select_expression_long_to_string(async);
 
         AssertMql(
+            """
+            Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "ShipName" : { "$toString" : { "$toLong" : "$_id" } }, "_id" : 0 } }
+            """
 );
     }
 
     public override async Task Select_expression_int_to_string(bool async)
     {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_int_to_string(async))).Message);
+        await base.Select_expression_int_to_string(async);
 
         AssertMql(
-);
+            """
+            Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "ShipName" : { "$toString" : "$_id" }, "_id" : 0 } }
+            """
+        );
     }
 
     public override async Task ToString_with_formatter_is_evaluated_on_the_client(bool async)
     {
         // Fails: Client eval in final projection EF-250
         Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.ToString_with_formatter_is_evaluated_on_the_client(async))).Message);
+            "Expression not supported: o.OrderID.ToString(\"X\")",
+            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.ToString_with_formatter_is_evaluated_on_the_client(async))).Message);
 
         AssertMql(
-);
+            """
+            Orders.
+            """
+        );
     }
 
     public override async Task Select_expression_other_to_string(bool async)
     {
         // Fails: Client eval in final projection EF-250
         Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_other_to_string(async))).Message);
+            "cannot be called with instance of type",
+            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_other_to_string(async))).Message);
 
         AssertMql(
 );
@@ -2507,7 +2510,7 @@ Orders.{ "$match" : { "$and" : [{ "OrderDate" : { "$ne" : null } }, { "$expr" : 
     {
         // Fails: Projections issue EF-76
         Assert.Contains(
-            "Rewriting child expression",
+            "No coercion operator is defined",
             (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_date_add_milliseconds_large_number_divided(async))).Message);
 
         AssertMql(

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Storage/BsonBindingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Storage/BsonBindingTests.cs
@@ -64,7 +64,7 @@ public class BsonBindingTests
         var property = entity.GetProperty(nameof(TestEntity.IntProperty));
         var document = BsonDocument.Parse("{ IntProperty: 12 }");
 
-        var value = BsonBinding.GetPropertyValue<int>(document, property);
+        var value = BsonBinding.GetPropertyValue<int>(document, null, property);
 
         Assert.Equal(12, value);
     }
@@ -81,7 +81,7 @@ public class BsonBindingTests
         var property = entity.GetProperty(nameof(TestEntity.IntProperty));
         var document = BsonDocument.Parse("{ property: 12 }");
 
-        var ex = Assert.Throws<InvalidOperationException>(() => BsonBinding.GetPropertyValue<int>(document, property));
+        var ex = Assert.Throws<InvalidOperationException>(() => BsonBinding.GetPropertyValue<int>(document, null, property));
         Assert.Contains("IntProperty", ex.Message);
     }
 
@@ -97,7 +97,7 @@ public class BsonBindingTests
         var property = entity.GetProperty(nameof(TestEntity.NullableProperty));
 
         var document = BsonDocument.Parse("{ somevalue: 12 }");
-        var value = BsonBinding.GetPropertyValue<int?>(document, property);
+        var value = BsonBinding.GetPropertyValue<int?>(document, null, property);
 
         Assert.Null(value);
     }


### PR DESCRIPTION
That is, the IProperty or INavigation associated with the access. Types, requiredness, type-mappings, etc. are then obtained from the property.

An alias is passed in if the name in the BSON document is different from the mapped element name for the property.