### PR TITLE
EF-107: Bulk ExecuteUpdate/ExecuteDelete — single-command and transactional two-phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Entity Framework Core and MongoDB have a wide variety of features. This provider
 - MongoDB full text search (Previously known as Atlas Search)
 - MongoDB vector search (Previously known as Atlas Vector Search)
 - [Client Side Field Level Encryption](https://www.mongodb.com/docs/manual/core/csfle/quick-start/) and [Queryable Encryption](https://www.mongodb.com/docs/manual/core/queryable-encryption/) compatibility
+- Bulk `ExecuteUpdate` and `ExecuteDelete` (EF 9+) on a single collection; supports constant and self-referencing setters; bypasses the change tracker (concurrency tokens are not checked)
+  - `Where`-scoped sources execute as a single atomic `deleteMany` / `updateMany` server command
+  - Sources that also use `OrderBy`/`ThenBy`/`Skip`/`Take`/`Distinct` are supported via a transactional two-phase execution (phase 1 collects the target `_id`s; phase 2 acts on them via `{ _id: { $in: [...] } }`); requires a transaction-capable deployment (replica set or sharded cluster); under `AutoTransactionBehavior.Never` the caller must open an explicit transaction
+  - Not supported: joins, `GroupBy`, `SelectMany`, set operations, cross-document navigation predicates, or multiple-collection updates
 
 ## Limitations
 
@@ -107,7 +111,6 @@ in the mean-time consider using the existing [MongoDB C# Driver's](https://githu
 - GroupBy operations
 - Includes/joins
 - Geospatial
-- ExecuteUpdate & ExecuteDelete bulk operations (EF 9+)
 
 ### Not supported, out-of-scope features
 

--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -81,7 +81,7 @@ These entries appear in `// Fails:` comments without an `EF-` or `CSHARP-` refer
 | Temp ticket | Subject | Count |
 | --- | --- | --- |
 | EF-X001 | Sub-query selection across DbSets is not translated | 144 |
-| EF-X002 | Provider throws a different exception than the EF translation-failure message | 44 |
+| EF-X002 | Provider throws a different exception than the EF translation-failure message | 46 |
 | EF-X003 | Driver-level feature gaps surfaced as test failures | 19 |
 | EF-X004 | Float `Sum`/`Average` truncation (likely duplicate of EF-228) | 1 |
 | EF-X005 | BSON document missing nested required reference (AdHoc JSON) | 2 |
@@ -101,6 +101,7 @@ These entries appear in `// Fails:` comments without an `EF-` or `CSHARP-` refer
 | EF-X019 | Include on keyless entity not supported (no primary key for $lookup join) | 2 |
 | EF-X020 | Cross-collection Include/join/navigation not translated on EF8/EF9 (works on EF10) | 168 |
 | EF-X021 | Filtered Include / query filter on cross-collection target not translated | 0 |
+| EF-X016 | Bulk `ExecuteUpdate`/`ExecuteDelete` source restricted to a single collection scoped by `Where` | 47 |
 
 ### EF-X001 — Sub-query selection across DbSets is not translated
 Comment patterns: `// Fails: Subquery selection EF-X001`, `// Fails: Subqueries not supported EF-X001`, `// Fails: No subquery support EF-X001`.
@@ -109,7 +110,7 @@ Affected: ~140 tests across `NorthwindAggregateOperators`, `NorthwindMiscellaneo
 
 ### EF-X002 — Provider throws a different exception than the EF translation-failure message
 Comment patterns: `// Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002`, `// Fails: Not throwing expected translation failed exception from EF. EF-X002`, `// Fails: Does not throw expected unable to translate exception EF-X002`, `// Fails: Does not use translation failed message EF-X002`, `// Fails: Throws different exception, but still throws EF-X002`.
-Affected: ~34 tests. EF's base tests expect `InvalidOperationException` with EF's "could not be translated" message; the provider currently throws `ExpressionNotSupportedException` / `MongoCommandException` / `NotSupportedException` instead. Aligning the messages would let EF-level diagnostics work without provider-specific overrides.
+Affected: ~36 tests. EF's base tests expect `InvalidOperationException` with EF's "could not be translated" message; the provider currently throws `ExpressionNotSupportedException` / `MongoCommandException` / `NotSupportedException` instead. Aligning the messages would let EF-level diagnostics work without provider-specific overrides. Two of these are bulk-update shapes in `NorthwindBulkUpdatesMongoTest` — `Update_Concat_set_constant` / `Update_Union_set_constant`, asserted with `Assert.ThrowsAnyAsync<Exception>`. These are a **test-harness/transaction artifact rather than a bulk-path defect**: the conformance asserter's before/after snapshot query mirrors the `Concat`/`Union` source as `$unionWith`, which the server forbids inside the rollback transaction the fixture enlists (`MongoCommandException: Stage not supported inside of a multi-document transaction: $unionWith`) — so it fails before the provider's own clean bulk rejection. (The two GroupBy bulk shapes that previously sat here — `Delete_Where_predicate_with_GroupBy_aggregate`, `Delete_GroupBy_Where_Select_2` — now reject with the canonical translation-failure message via the bulk translation guard and are tracked under EF-X016.)
 
 ### EF-X003 — Driver-level feature gaps surfaced as test failures
 Comment patterns: `// Fails: Unsupported by driver EF-X003`, `// Fails: Reverse not supported by driver EF-X003`, `// Fails: Limited support on client evaluation EF-X003`.
@@ -162,6 +163,26 @@ Affected: 1 test (`NorthwindSelectQueryMongoTest.Select_bool_closure_with_order_
 ### EF-X015 — Sub-second `DateTime` component translation (nanosecond/microsecond)
 Comment pattern: `// Fails: Sub-second DateTime component translation EF-X015`.
 Affected: 1 test (`NorthwindMiscellaneousQueryMongoTest.Where_nanosecond_and_microsecond_component`). `DateTime.Nanosecond` and `DateTime.Microsecond` (added in .NET 7) are not translated; the provider throws `ExpressionNotSupportedException`.
+
+### EF-X016 — Bulk `ExecuteUpdate`/`ExecuteDelete` source restricted to a single collection scoped by `Where`
+Comment pattern: `// Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; <shape> unsupported EF-X016`.
+Test-body pattern: `AssertTranslationFailed(() => base.X(...))`.
+Affected: 47 tests in `NorthwindBulkUpdatesMongoTest.cs`. By design, the provider supports bulk `ExecuteUpdate`/`ExecuteDelete` only against a single collection scoped by `Where`, with constant / parameter / self-referencing scalar setters (see README "What is supported" and EF-107). The EF conformance suite exercises shapes outside that subset — joins / correlated subqueries, set operations (`Except`/`Intersect`), `GroupBy`, `SelectMany`, cross-document navigation predicates, non-entity projection sources, and multiple-collection updates — and the provider rejects them during translation with an `InvalidOperationException` whose message reports the LINQ expression could not be translated. This is a documented limitation rather than a bug to fix; the ticket tracks the boundary so any future expansion of the supported subset (or a behavior change) is detected. Most shapes are rejected by compile-time bulk-source validation; a few (e.g. a `GroupBy` subquery inside the `Where` predicate) only fail when the filter is built at execution time, where a translation guard (`TranslateBulkOrThrow` in `MongoShapedQueryCompilingExpressionVisitor`) converts the raw driver/expression exception into the same canonical non-query translation failure. A handful of sibling shapes surface differently and are tagged separately: cross-DbSet `GroupBy` rejections under [EF-216](https://jira.mongodb.org/browse/EF-216), and the `$unionWith`-in-transaction `Concat`/`Union` cases under `EF-X002`.
+
+**Remaining unsupported shapes — grouped by root cause.** The unifying cause: two-phase execution only works when the *source query is translatable as a read*, because phase 1 must be able to project the target `_id`s. Every group below fails because the source shape itself cannot be translated — so neither phase 1 nor a single-command filter can be built. (Delete has the analogous cases; the `Update_*` methods are enumerated here since they are the larger set.)
+
+- **Joins / correlated subqueries** — `Join` / `LeftJoin` / `RightJoin` / `GroupJoin`, cross-apply, outer-apply. The read path doesn't translate joins (the `Translate*Join` overrides return null / route to a clean "not supported"), so phase 1 cannot project `_id`s. Unblocking requires net-new read-side join translation (ultimately a driver `$lookup`/`$group` + `$merge` capability) and is out of scope for EF-107. Update cases: `Update_Where_Join_set_property_from_joined_single_result_scalar`, `Update_Where_Join_set_property_from_joined_single_result_table`, `Update_Where_Join_set_property_from_joined_table`, `Update_with_join_set_constant`, `Update_with_two_inner_joins`, `Update_with_left_join_set_constant`, `Update_with_cross_join_set_constant`, `Update_with_cross_apply_set_constant`, `Update_with_outer_apply_set_constant`, `Update_with_cross_join_cross_apply_set_constant`, `Update_with_cross_join_left_join_set_constant`, `Update_with_cross_join_outer_apply_set_constant`, `Update_with_PK_pushdown_and_join_and_multiple_setters`, plus EF10-only `Update_with_LeftJoin`, `Update_with_LeftJoin_via_flattened_GroupJoin`, `Update_with_RightJoin`.
+- **Set operations — `Except` / `Intersect`** — MongoDB has no cross-collection intersect/except (only `$unionWith`), so the source cannot be expressed and is rejected at translation. Update cases: `Update_Except_set_constant`, `Update_Intersect_set_constant`.
+- **`SelectMany`** — the read path has no cross-document flattening, so the source cannot be translated. Update cases: `Update_Where_SelectMany_set_null`, `Update_Where_SelectMany_subquery_set_null`.
+- **Cross-document navigation predicates** — predicates traversing navigations across collections aren't translatable. Update cases: `Update_Where_using_navigation_2_set_constant`, `Update_Where_using_navigation_set_null`.
+- **Multiple-collection update** — a relational table-sharing concept with no document-model meaning; rejected by design regardless of phase strategy. Update case: `Update_multiple_tables_throws`.
+
+**Related shapes that surface as a different failure mode** (cross-referenced, not under the canonical translation-failure pattern above):
+
+- **`Concat` / `Union` (`EF-X002`)** — these lower to `$unionWith`, which the server forbids inside the multi-document transaction the conformance asserter (and the two-phase path) run in, so they throw a runtime `MongoCommandException` *before* the provider's clean bulk rejection. Update cases: `Update_Concat_set_constant`, `Update_Union_set_constant`. Unblocking requires the server to allow `$unionWith` inside a transaction.
+- **`GroupBy`-scoped (`EF-216`)** — `GroupBy` isn't translatable; these surface as the provider's `Unsupported cross-DbSet query` rejection and are asserted via `AssertNoMultiCollectionQuerySupport` rather than a `// Fails:` `AssertTranslationFailed`. Update cases: `Update_Where_GroupBy_First_set_constant`, `Update_Where_GroupBy_First_set_constant_2`, `Update_Where_GroupBy_First_set_constant_3`, `Update_Where_GroupBy_aggregate_set_constant`.
+
+**Two-phase bulk support (EF-107):** `OrderBy`/`Skip`/`Take`/`Distinct`-scoped bulk delete and update are now supported via a transactional two-phase execution strategy: phase 1 projects the matching `_id` values (including composite-key entities) into a temporary in-memory set; phase 2 issues the actual `deleteMany`/`updateMany` scoped to that `_id` set. The corresponding conformance tests (`Delete_Where_OrderBy*`, `Delete_Where_Skip*`, `Delete_Where_Take*`, `Delete_Where_Distinct`, `Update_Where_OrderBy*`, `Update_Where_Skip*`, `Update_Where_Take*`, `Update_Where_Distinct_set_constant`, `Delete_Where_Skip_Take_Skip_Take_causing_subquery`, `Update_Where_OrderBy_Skip_Take_Skip_Take_set_constant`) have been promoted from `AssertTranslationFailed` to `base.*` and are no longer tracked under this ticket.
 
 ### EF-X016 — GroupJoin shapes not translated
 Comment pattern: `// Fails: GroupJoin shape not translated EF-X016`.
@@ -262,4 +283,5 @@ grep -rEho "(EF-X?[0-9]+|CSHARP-[0-9]+)" tests/.../SpecificationTests --include=
   | sort | uniq -c | sort -rn
 ```
 
-returns 49 distinct ticket ids, including 15 temporary `EF-X###` placeholders. The static audit (lookback-5 search for `// Fails:` above any `AssertTranslationFailed` / `Assert.Throws*` / `AssertGroupByUnsupported` callsite, excluding helper definitions and single-mode helper callers) reports zero remaining holes among Mongo-failure cases.
+returns 50 distinct ticket ids, including 16 temporary `EF-X###` placeholders (`EF-X016` was
+added for the `NorthwindBulkUpdatesMongoTest` out-of-subset rejections). The static audit (lookback-5 search for `// Fails:` above any `AssertTranslationFailed` / `Assert.Throws*` / `AssertGroupByUnsupported` callsite, excluding helper definitions and single-mode helper callers) reports zero remaining holes among Mongo-failure cases.

--- a/docs/superpowers/plans/2026-06-09-execute-update-delete.md
+++ b/docs/superpowers/plans/2026-06-09-execute-update-delete.md
@@ -1,0 +1,1003 @@
+# ExecuteUpdate / ExecuteDelete Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement EF Core's `ExecuteDelete`/`ExecuteUpdate` bulk-operation APIs (EF9 + EF10) so they run a single server-side `deleteMany`/`updateMany` against one collection, scoped by the query's `Where` predicate, bypassing the change tracker.
+
+**Architecture:** New `TranslateExecuteDelete`/`TranslateExecuteUpdate` overrides on `MongoQueryableMethodTranslatingExpressionVisitor` produce a new `MongoNonQueryExpression` marker node. `MongoShapedQueryCompilingExpressionVisitor.VisitExtension` recognizes that node and emits a call to a static executor that builds a `FilterDefinition<BsonDocument>` (and, for update, an `UpdateDefinition<BsonDocument>`) from the captured predicate/setters and runs `DeleteMany`/`UpdateMany`, returning the affected count. The predicate and self-referencing-value translation reuse `MongoEFToLinqTranslatingExpressionVisitor` (the same machinery the vector-search pre-filter uses).
+
+**Tech Stack:** C# / .NET 8 & 10, EF Core 9/10 (`#if !EF8`), MongoDB C# driver 3.9.0, xUnit + FluentAssertions.
+
+**Key constraints (from the design doc `docs/superpowers/specs/2026-06-09-execute-update-delete-design.md`):**
+- EF9 + EF10 only. All new code gated `#if !EF8`. `TranslateExecuteUpdate` signature differs EF9 vs EF10.
+- Source query may only contain `Where` filtering (+ the implicit discriminator filter for TPH). `OrderBy`/`Skip`/`Take`/`Select`/`Distinct`/joins/set-ops/cross-collection ⇒ throw the canonical EF translation-failure message.
+- Update setters target **root scalar properties only**. Constants/parameters ⇒ `$set`; self-referencing (`e => e.Count + 1`) ⇒ aggregation pipeline-form update.
+- Transactions: thread `CurrentTransaction.Session` if open; otherwise a single un-wrapped command. No implicit transaction.
+- Bypasses change tracker; concurrency tokens not checked. Returns `int` (cast from driver `long`).
+
+**Conventions to follow:**
+- Preserve file BOMs on edits. `<Nullable>enable</Nullable>` — annotate new types.
+- Build a single version: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF9"` (or `EF10`).
+- Run a filtered test: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF9" --no-build --filter "FullyQualifiedName~ExecuteUpdateDelete"`.
+- Functional/spec tests need MongoDB (env `MONGODB_URI`/`ATLAS_URI`, else Docker auto-spins). Tests run serially.
+- First commit message + branch are JIRA-tagged (`EF-NNN`). Branch `EF-execute-update-delete` already exists with the design doc committed. Replace `EF-NNN` with the real ticket once filed.
+
+---
+
+## Phase 0 — Spikes (resolve the two rendering unknowns first)
+
+These two spikes empirically determine driver-3.9.0 APIs that the production tasks depend on. Each produces a throwaway test that prints rendered BSON and a written decision appended to this plan. **Do not skip** — the production code in Phases 2 and 4 is written against the *expected* API and must be reconciled with the spike output.
+
+### Task 0A: Spike — render an EF predicate to a `FilterDefinition<BsonDocument>`
+
+**Goal:** Determine exactly how to turn a translated entity predicate lambda into a `BsonDocument` filter whose element names honor EF configuration (camel-case, `[Column]`/`HasElementName`, discriminators), using the EF entity serializer — because `IMongoCollection<TEntity>` does NOT use EF's serializer (it's applied per-query via `.As(serializer)`).
+
+**Files:**
+- Test (throwaway): `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateDeleteSpikeTests.cs`
+
+- [ ] **Step 1: Write a spike test that renders a filter and prints it**
+
+Use an existing functional-test entity that has a renamed/camel-cased element so a wrong serializer is observable. Pick one from `tests/MongoDB.EntityFrameworkCore.FunctionalTests` (e.g. an entity mapped with `HasElementName` or camel-case convention — search the test models). Replace `TEntity`/`SomeEntity` and the property below with that concrete type.
+
+```csharp
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+public sealed class ExecuteUpdateDeleteSpikeTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void Render_predicate_to_bson_filter()
+    {
+        // Arrange: build the translated driver-LINQ predicate the way the production
+        // executor will. For the spike, hand-build a simple predicate over TEntity.
+        // Goal: render it to a BsonDocument with EF element names.
+        // Candidate API (confirm against driver 3.9.0):
+        //   var filter = new ExpressionFilterDefinition<TEntity>(predicateLambda);
+        //   var serializer = (IBsonSerializer<TEntity>)bsonSerializerFactory.GetEntitySerializer(entityType);
+        //   var bson = filter.Render(new RenderArgs<TEntity>(serializer, BsonSerializer.SerializerRegistry));
+        // Print `bson` and assert the element name matches the EF-configured name, NOT the CLR name.
+        output.WriteLine("TODO: print rendered filter");
+    }
+}
+```
+
+- [ ] **Step 2: Build and run; iterate on the real API**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF9"` then
+`dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF9" --no-build --filter "FullyQualifiedName~ExecuteUpdateDeleteSpikeTests"`
+Inspect compiler errors / runtime output to discover the exact `FilterDefinition<T>.Render(...)` overload in driver 3.9.0 (likely `Render(RenderArgs<TDocument>)`; older shape is `Render(IBsonSerializer<TDocument>, IBsonSerializerRegistry)`). Confirm the rendered element name is the EF-configured one when the EF serializer is passed, and is wrong (CLR name) when the default serializer is passed — proving the serializer must be the EF one.
+
+- [ ] **Step 3: Determine how to source the predicate lambda from the captured chain**
+
+The source `MongoQueryExpression.CapturedExpression` is the post-EF method chain (`root.Where(...).Where(...)`, possibly with a discriminator filter). Decide the extraction approach and verify it: run each `Where` lambda body through a `MongoEFToLinqTranslatingExpressionVisitor` and combine with `AndAlso` under a single shared `ParameterExpression` of the entity type. Confirm the vector-search pre-filter path (`MongoEFToLinqTranslatingExpressionVisitor` `ProcessVectorSearch`, which does `new ExpressionFilterDefinition<TEntity>(Visit(preFilterExpression))`) renders correctly when later combined with `.As(serializer)` — and whether `Render` with the EF serializer reproduces that.
+
+- [ ] **Step 4: Write the decision into this plan**
+
+Append a "Spike 0A result" subsection below recording: the exact `Render` call for driver 3.9.0, the predicate-extraction approach, and how a multi-`Where` chain and the discriminator filter are combined. Phase 2 consumes this.
+
+- [ ] **Step 5: Commit the spike test and decision**
+
+```bash
+git add docs/superpowers/plans/2026-06-09-execute-update-delete.md tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateDeleteSpikeTests.cs
+git commit -m "EF-NNN: Spike filter rendering for ExecuteDelete"
+```
+
+#### Spike 0A result (verified against driver 3.9.0, EF9)
+
+**Status: PROVEN.** The `Render`-with-EF-serializer approach produces correct (EF-configured) element names; the default driver serializer produces the wrong (CLR) name, confirming the serializer is load-bearing. End-to-end `DeleteMany` on a `BsonDocument` collection with the rendered filter deletes exactly the EF-stored documents. Spike test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateDeleteSpikeTests.cs` (3 tests, all pass).
+
+Observed renders (entity `Person` with `Property(e => e.FirstName).HasElementName("forename")`, `LastName` left as CLR name):
+
+| Render path | Predicate | Rendered BSON |
+|---|---|---|
+| **EF serializer** | `p => p.FirstName == "Ada"` | `{ "forename" : "Ada" }` ✅ |
+| Default driver serializer | `p => p.FirstName == "Ada"` | `{ "FirstName" : "Ada" }` ❌ (CLR name) |
+| EF serializer (combined) | `p => p.FirstName == "Ada" && p.LastName == "Lovelace"` | `{ "forename" : "Ada", "LastName" : "Lovelace" }` ✅ |
+
+**1. Exact `Render` call (driver 3.9.0).** `FilterDefinition<TDocument>` exposes a *single* `Render` overload: `BsonDocument Render(RenderArgs<TDocument> args)`. The older two-arg `Render(IBsonSerializer<TDocument>, IBsonSerializerRegistry)` shape does **not** exist in 3.9.0. `RenderArgs<TDocument>` has one public ctor — `RenderArgs(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry, PathRenderArgs = default, bool renderForFind = default, bool renderForElemMatch = default, bool renderDollarForm = default, ExpressionTranslationOptions = default)` — so the trailing args default and the call is two-arg in practice:
+
+```csharp
+var efSerializer = (IBsonSerializer<TEntity>)bsonSerializerFactory.GetEntitySerializer(entityType);
+var filter       = new ExpressionFilterDefinition<TEntity>(predicateLambda);   // Expression<Func<TEntity,bool>>
+BsonDocument bson = filter.Render(new RenderArgs<TEntity>(efSerializer, BsonSerializer.SerializerRegistry));
+```
+
+`GetEntitySerializer(IReadOnlyEntityType)` is `internal` on `BsonSerializerFactory`; the spike added `MongoDB.EntityFrameworkCore.FunctionalTests` to `<InternalsVisibleTo>` in `src/.../MongoDB.EntityFrameworkCore.csproj` (the production executor lives in `src` so it needs no IVT; this IVT is for the test layer and is reused by the production tests in Phase 2).
+
+The production executor builds an `IMongoCollection<BsonDocument>` (matching the write pipeline), so the rendered `BsonDocument` is passed straight to `DeleteMany(rendered)`. Convert to a typed filter where the driver API wants one via `new BsonDocumentFilterDefinition<BsonDocument>(bson)`, or keep the `BsonDocument` directly for `DeleteMany`/`UpdateMany`.
+
+**2. Predicate-extraction approach.** The source is `MongoQueryExpression.CapturedExpression` — the post-EF method chain (`root.Where(λ₁).Where(λ₂)…`, optionally carrying a TPH discriminator `Where`). Extraction:
+   - Walk the chain collecting each `Where`'s predicate lambda body.
+   - Run each body through a `MongoEFToLinqTranslatingExpressionVisitor` (constructed exactly as in `MongoShapedQueryCompilingExpressionVisitor.TranslateQuery`, `:188-214` — it rewrites `EF.Property(p,"x")` → `Mql.Field(p,"elementName",serializer)` and resolves query-parameter bindings to constants).
+   - Combine the translated bodies under a **single shared `ParameterExpression`** of the entity CLR type with `Expression.AndAlso`, then `Expression.Lambda<Func<TEntity,bool>>(combined, param)`.
+   - Wrap in `ExpressionFilterDefinition<TEntity>` and `Render` as above.
+
+   The spike proved the combine-with-`AndAlso`-under-one-parameter step renders correctly (`{ "forename": ..., "LastName": ... }`). For predicates the EF visitor lowers to `Mql.Field(...)`, the element name is baked into the expression itself, so it is already correct; the EF serializer is still required so that *plain CLR-member* references (and nested/owned shapes) resolve to EF element names rather than driver defaults — which is exactly the EF-vs-default contrast the spike measured.
+
+**3. Multi-`Where` and discriminator filter.** Multiple `Where`s combine via `AndAlso` under the shared parameter (proven). The TPH discriminator filter rides along as just another `Where` in the captured chain, so it is picked up by the same walk and `AndAlso`-combined — no special-casing needed. (Discriminator-specific end-to-end coverage is deferred to Task 5; the mechanism is identical to any other `Where`.)
+
+**4. Vector-search pre-filter parity.** The vector-search path (`MongoEFToLinqTranslatingExpressionVisitor`, ~`:366-374`) builds `ExpressionFilterDefinition<TEntity>(Visit(preFilterExpression))` and assigns it to `VectorSearchOptions.Filter`, where the driver renders it **inside** the aggregation pipeline after `.As(efSerializer)` has already been applied — so it never calls `Render` explicitly. The `DeleteMany`-on-`BsonDocument` path has **no** `.As()`, which is precisely why this executor must `Render` with the EF serializer itself. Both paths reach the same rendered shape; the only difference is *where* the serializer is supplied (implicitly via `.As()` for vector search vs. explicitly via `RenderArgs` for the bulk executor). Confirmed: the same `ExpressionFilterDefinition<TEntity>` rendered with the EF serializer reproduces the EF element names.
+
+### Task 0B: Spike — render a self-referencing setter value to a pipeline `$set`
+
+**Goal:** Determine how to render `e => e.Count + 1` to the aggregation expression `{ $add: ["$count", 1] }` and assemble a pipeline-form `UpdateDefinition<BsonDocument>` (`[{ $set: { count: { $add: ["$count", 1] } } }]`) using the EF serializer, in driver 3.9.0.
+
+**Files:**
+- Test (throwaway): extend `ExecuteUpdateDeleteSpikeTests.cs`.
+
+- [ ] **Step 1: Write a spike test that builds and prints a pipeline update**
+
+```csharp
+[Fact]
+public void Render_self_referencing_setter_to_pipeline_update()
+{
+    // Candidate approaches to evaluate (pick whichever driver 3.9.0 supports cleanly):
+    //  A) Builders<BsonDocument>.Update.Pipeline(PipelineDefinition<BsonDocument,BsonDocument>)
+    //     where the $set stage is a BsonDocument built from a rendered aggregation expression.
+    //  B) Render the value via the driver's aggregation-expression translation
+    //     (the same translation MongoEFToLinqTranslatingExpressionVisitor feeds the LINQ provider).
+    // Print the resulting update document and assert it equals
+    //   [{ "$set": { "<element>": { "$add": ["$<element>", 1] } } }]
+    output.WriteLine("TODO: print rendered pipeline update");
+}
+```
+
+- [ ] **Step 2: Build, run, iterate to find the real rendering path**
+
+Run the same build/test commands as 0A (filter to this test). The key unknown is rendering an arbitrary value expression to an aggregation-expression `BsonValue` with EF element names. Investigate whether `MongoEFToLinqTranslatingExpressionVisitor` output can be rendered via a `$project`/`$set` probe (e.g. translate `source.Select(e => new { v = e.Count + 1 })` and capture the rendered stage), or whether the driver exposes a direct expression-to-`BsonValue` renderer.
+
+- [ ] **Step 3: Decide scope per the design's fallback**
+
+If a robust rendering path exists, record it. If it proves disproportionate for driver 3.9.0, invoke the design's documented fallback: **ship constants-only `$set` in v1, defer self-referencing to a fast-follow.** Record the decision explicitly.
+
+- [ ] **Step 4: Write "Spike 0B result" into this plan and commit**
+
+```bash
+git add docs/superpowers/plans/2026-06-09-execute-update-delete.md tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateDeleteSpikeTests.cs
+git commit -m "EF-NNN: Spike self-referencing pipeline-update rendering"
+```
+
+#### Spike 0B result (verified against driver 3.9.0, EF9 + EF10)
+
+**Status: PROVEN — a robust rendering path exists. The constants-only fallback is NOT needed.** Self-referencing setters (`o => o.Quantity + 1`) render to an aggregation-expression `BsonValue` with EF element names via a *direct* driver renderer — no `$project`/`$set` query probe, no `LoggedStages` capture, no query execution required. Spike test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateDeleteSpikeTests.cs` (3 new tests added under "SPIKE 0B"; all 6 tests in the file pass under both `Debug EF9` and `Debug EF10`).
+
+Observed renders (entity `Order` with `Property(e => e.Quantity).HasElementName("qty")`):
+
+| Render path | Value expression | Rendered `BsonValue` |
+|---|---|---|
+| **EF serializer** | `o => o.Quantity + 1` | `{ "$add" : ["$qty", 1] }` ✅ (EF element name) |
+| Default driver serializer | `o => o.Quantity + 1` | `{ "$add" : ["$Quantity", 1] }` ❌ (CLR name) |
+| EF serializer, visitor-shaped lambda | `o => Mql.Field(o, "qty", <int ser>) + 1` | `{ "$add" : ["$qty", 1] }` ✅ |
+
+End-to-end (`UpdateMany` on a `BsonDocument` collection with the assembled pipeline update): documents seeded via EF (`qty` 10/20 with `Status="open"`, 99 with `"closed"`), filtered to `Status == "open"`, incremented → `ModifiedCount == 2`, stored `qty` became `11`/`21`, the `"closed"` doc stayed `99`. ✅
+
+**1. The renderer (driver 3.9.0).** Driver exposes `ExpressionAggregateExpressionDefinition<TSource, TResult>` with a **public** ctor `ExpressionAggregateExpressionDefinition(Expression<Func<TSource, TResult>> expression)` and `BsonValue Render(RenderArgs<TSource> args)`. This is the aggregation-expression analogue of `ExpressionFilterDefinition<T>` from Spike 0A, and it uses the *same* `RenderArgs<TSource>` two-arg form:
+
+```csharp
+var efSerializer = (IBsonSerializer<TSource>)bsonSerializerFactory.GetEntitySerializer(entityType);
+var valueExpr    = (Expression<Func<TSource, TResult>>)translatedValueLambda;   // driver-LINQ form
+BsonValue rendered = new ExpressionAggregateExpressionDefinition<TSource, TResult>(valueExpr)
+    .Render(new RenderArgs<TSource>(efSerializer, BsonSerializer.SerializerRegistry));
+// rendered == { "$add" : ["$qty", 1] }
+```
+
+As with 0A, the EF serializer is load-bearing: the default driver serializer renders the CLR name (`$Quantity`), the EF serializer renders the configured element name (`$qty`).
+
+**2. Value-expression extraction.** The user's value body (`o => o.Quantity + 1`, or the EF9 `SetProperty(sel, val)` value, or the EF10 `ExecuteUpdateSetter.ValueExpression`) is translated through a `MongoEFToLinqTranslatingExpressionVisitor` constructed exactly as in `MongoShapedQueryCompilingExpressionVisitor.TranslateQuery` (`:188-214`) — the same machinery Phase 2 uses for the predicate. The visitor lowers `EF.Property(o,"Quantity")` / CLR member access to `Mql.Field(o, "qty", <typeSerializer>)`, so the element name is baked into the expression even before `Render`. The spike proved both shapes render identically: a plain-CLR lambda (`o => o.Quantity + 1`) **and** a hand-built visitor-shaped lambda (`o => Mql.Field(o,"qty",ser) + 1`) both produce `{ $add: ["$qty", 1] }`. Wrap the translated body in `Expression.Lambda<Func<TSource, TResult>>(body, entityParam)` (`TResult` = the property CLR type, e.g. `int`).
+
+**3. Assembling the pipeline update.** Build one `$set` stage as a `BsonDocument` keyed by `property.GetElementName()`, value = the rendered `BsonValue`; wrap with `PipelineDefinition<BsonDocument,BsonDocument>.Create(new[] { setStage })` and `Builders<BsonDocument>.Update.Pipeline(pipeline)`:
+
+```csharp
+var setStage = new BsonDocument("$set", new BsonDocument(property.GetElementName(), rendered));
+var pipeline = PipelineDefinition<BsonDocument, BsonDocument>.Create(new[] { setStage });
+var update   = Builders<BsonDocument>.Update.Pipeline(pipeline);   // UpdateDefinition<BsonDocument>
+// pipeline form: [{ "$set" : { "qty" : { "$add" : ["$qty", 1] } } }]
+```
+
+For **Task 8**, multiple setters merge into the single `$set` stage: self-referencing values contribute their rendered `BsonValue`; constant/parameter values contribute the serialized literal (the same `SerializePropertyValue` path as the constant `$set` in Task 6). A mixed call (some constant, some self-referencing) is therefore one `$set` stage with a mix of literal and aggregation-expression values — which a pipeline `$set` handles natively (literals and `$expr`-style values coexist in `$set`). The constant-only path (Task 6) can stay on the cheaper `BsonDocumentUpdateDefinition` `{ $set: {...} }` document form; only when *any* setter is self-referencing does `BuildUpdate` switch to the pipeline form.
+
+**4. No fallback required.** The design's documented fallback (ship constants-only `$set` in v1, defer self-referencing) is **not** invoked. The renderer is a first-class, public driver API (`ExpressionAggregateExpressionDefinition` + `Render`), reuses the exact `RenderArgs`/EF-serializer mechanism already proven in 0A, and works unchanged on EF9 and EF10. Task 8 proceeds as the pipeline-update implementation (not the throw-and-defer variant).
+
+> After Phase 4, delete `ExecuteUpdateDeleteSpikeTests.cs` (its behavior is covered by the real tests). A cleanup step is included in Task 9.
+
+---
+
+## Phase 1 — The marker expression node
+
+### Task 1: `MongoNonQueryExpression`
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoNonQueryExpression.cs`
+- Test: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoNonQueryExpressionTests.cs`
+
+- [ ] **Step 1: Write the failing unit test**
+
+```csharp
+using System.Linq.Expressions;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using Xunit;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.Expressions;
+
+public class MongoNonQueryExpressionTests
+{
+    [Fact]
+    public void Delete_node_exposes_source_and_kind()
+    {
+        var source = new MongoQueryExpression(Mock.EntityType()); // use existing test helper for an IEntityType-backed MongoQueryExpression
+        var node = new MongoNonQueryExpression(source);
+
+        node.Kind.Should().Be(MongoNonQueryExpression.OperationKind.Delete);
+        node.SourceQuery.Should().BeSameAs(source);
+        node.Type.Should().Be(typeof(int));
+        node.Setters.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Update_node_carries_setters()
+    {
+        var source = new MongoQueryExpression(Mock.EntityType());
+        var property = Mock.Property();                          // existing test helper
+        Expression value = Expression.Constant(5);
+        var setters = new[] { new MongoNonQueryExpression.Setter(property, value, IsSelfReferencing: false) };
+
+        var node = new MongoNonQueryExpression(source, setters);
+
+        node.Kind.Should().Be(MongoNonQueryExpression.OperationKind.Update);
+        node.Setters.Should().ContainSingle().Which.Property.Should().BeSameAs(property);
+    }
+}
+```
+
+Note: replace `Mock.EntityType()`/`Mock.Property()` with whatever the UnitTests project already uses to construct an `IEntityType`/`IProperty` and a `MongoQueryExpression` (search `tests/MongoDB.EntityFrameworkCore.UnitTests/Query` for existing patterns; the project has expression tests already).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF9" --filter "FullyQualifiedName~MongoNonQueryExpressionTests"`
+Expected: FAIL — `MongoNonQueryExpression` does not exist.
+
+- [ ] **Step 3: Implement the node**
+
+```csharp
+/* Copyright 2023-present MongoDB Inc. ... (copy the standard license header from a sibling file in Query/Expressions/) */
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace MongoDB.EntityFrameworkCore.Query.Expressions;
+
+/// <summary>
+/// Marker node produced by ExecuteDelete / ExecuteUpdate translation. Carries the source
+/// query (collection + captured predicate chain) and, for updates, the ordered setters.
+/// Recognized by <see cref="Visitors.MongoShapedQueryCompilingExpressionVisitor"/>.
+/// </summary>
+internal sealed class MongoNonQueryExpression : Expression
+{
+    public enum OperationKind { Delete, Update }
+
+    public sealed record Setter(IProperty Property, Expression ValueExpression, bool IsSelfReferencing);
+
+    public MongoNonQueryExpression(MongoQueryExpression sourceQuery)
+    {
+        SourceQuery = sourceQuery;
+        Kind = OperationKind.Delete;
+        Setters = [];
+    }
+
+    public MongoNonQueryExpression(MongoQueryExpression sourceQuery, IReadOnlyList<Setter> setters)
+    {
+        SourceQuery = sourceQuery;
+        Kind = OperationKind.Update;
+        Setters = setters;
+    }
+
+    public MongoQueryExpression SourceQuery { get; }
+    public OperationKind Kind { get; }
+    public IReadOnlyList<Setter> Setters { get; }
+
+    public override ExpressionType NodeType => ExpressionType.Extension;
+    public override System.Type Type => typeof(int);
+    public override bool CanReduce => false;
+
+    protected override Expression VisitChildren(System.Linq.Expressions.ExpressionVisitor visitor) => this;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF9" --filter "FullyQualifiedName~MongoNonQueryExpressionTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm it builds under EF10 too**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF10"`
+Expected: build succeeds (the node is version-agnostic; no `#if` needed on it, but it is only *referenced* from `#if !EF8` code).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoNonQueryExpression.cs tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoNonQueryExpressionTests.cs
+git commit -m "EF-NNN: Add MongoNonQueryExpression marker node"
+```
+
+---
+
+## Phase 2 — ExecuteDelete (end to end)
+
+### Task 2: Let the ExecuteDelete/ExecuteUpdate markers reach base dispatch
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs` (the `AllowedQueryableExtensions` gate at `:69-83`)
+
+**Context:** `VisitMethodCall` returns `NotTranslatedExpression` for any method whose declaring type isn't in `AllowedQueryableExtensions`. The `ExecuteDelete`/`ExecuteUpdate` markers are declared on `Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions`, so they'd be rejected before base dispatch. We must let them through to `base.VisitMethodCall`, which routes them to `TranslateExecuteDelete`/`TranslateExecuteUpdate`.
+
+- [ ] **Step 1: Add the EF extensions type to the allow-list (EF9+ only)**
+
+Edit the `AllowedQueryableExtensions` field and the early-return guard. Replace lines 69-83 region:
+
+```csharp
+    private static readonly Type[] AllowedQueryableExtensions =
+        [typeof(Queryable), typeof(MongoQueryableExtensions), typeof(Driver.Linq.MongoQueryable)];
+
+    protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+    {
+        var method = methodCallExpression.Method;
+        if (!AllowedQueryableExtensions.Contains(method.DeclaringType))
+        {
+#if !EF8
+            // ExecuteDelete/ExecuteUpdate markers live on EntityFrameworkQueryableExtensions; let the
+            // base visitor dispatch them to TranslateExecuteDelete/TranslateExecuteUpdate.
+            if (method.DeclaringType == typeof(Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions))
+            {
+                return base.VisitMethodCall(methodCallExpression);
+            }
+#endif
+            return QueryCompilationContext.NotTranslatedExpression;
+        }
+        // ... existing body unchanged ...
+```
+
+(Keep the rest of the method as-is.)
+
+- [ ] **Step 2: Build EF9 and EF10 to confirm it compiles**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF9"` and `... -c "Debug EF10"`
+Expected: both succeed. (Verify `EntityFrameworkQueryableExtensions` is the correct declaring type — confirm in Task 0/the EF source; for EF8 this code is excluded.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+git commit -m "EF-NNN: Allow ExecuteDelete/Update markers through method-source gate"
+```
+
+### Task 3: `TranslateExecuteDelete` override → marker
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs`
+
+- [ ] **Step 1: Add the override (EF9+), reusing the captured-expression discipline**
+
+Add inside the class, after `TranslateOfType` (around `:265`). The source's `MongoQueryExpression` already holds the collection and `CapturedExpression`; we set `CapturedExpression` to the full chain the same way the normal path does, then wrap in the marker. Reject unsupported source shapes by inspecting the captured chain.
+
+```csharp
+#if !EF8
+    protected override Expression? TranslateExecuteDelete(ShapedQueryExpression source)
+    {
+        var mongoQueryExpression = (MongoQueryExpression)source.QueryExpression;
+        ValidateBulkSource(mongoQueryExpression);          // throws translation-failure for non-filter chains
+        return new MongoNonQueryExpression(mongoQueryExpression);
+    }
+#endif
+```
+
+Add the validator helper (used by both delete and update):
+
+```csharp
+#if !EF8
+    // A bulk delete/update may only be scoped by Where filters (plus the implicit discriminator
+    // filter EF injects for TPH). Ordering, paging, projection, set-ops, joins have no server-side
+    // meaning for deleteMany/updateMany — reject them with EF's canonical translation-failure message.
+    private void ValidateBulkSource(MongoQueryExpression mongoQueryExpression)
+    {
+        var node = mongoQueryExpression.CapturedExpression;
+        while (node is MethodCallExpression call && call.Method.DeclaringType == typeof(Queryable))
+        {
+            switch (call.Method.Name)
+            {
+                case nameof(Queryable.Where):
+                    node = call.Arguments[0];
+                    break;
+                default:
+                    AddTranslationErrorDetails(
+                        $"The '{call.Method.Name}' operator cannot be used to scope a bulk ExecuteDelete/ExecuteUpdate; only 'Where' is supported.");
+                    throw new InvalidOperationException(
+                        CoreStrings.NonQueryTranslationFailedWithDetails(
+                            mongoQueryExpression.CapturedExpression?.Print(), TranslationErrorDetails));
+            }
+        }
+    }
+#endif
+```
+
+Notes for the implementer:
+- Confirm `CoreStrings.NonQueryTranslationFailedWithDetails` exists in EF9/EF10 (it does in relational/core; verify the exact name during build). If only `TranslationFailedWithDetails` is available in core, use that.
+- `CapturedExpression` may be `null` (direct `context.Set<T>().ExecuteDelete()` with no `Where`) — the `while` simply doesn't run, which is correct (delete all).
+- The discriminator filter for TPH is injected upstream as part of the captured chain and is itself a `Where`/predicate; it passes the validator. Confirm in the functional test for a derived type (Task 5 optional extension).
+
+- [ ] **Step 2: Build EF9/EF10**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF9"` / `-c "Debug EF10"`
+Expected: succeed (the executor doesn't exist yet, but `VisitExtension` will be added in Task 4 — until then a delete will fail at shaper compilation, which is fine; we add the behavior test in Task 5 after Task 4).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+git commit -m "EF-NNN: TranslateExecuteDelete produces MongoNonQueryExpression"
+```
+
+### Task 4: Executor + `VisitExtension` dispatch for delete
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs`
+
+**Context:** Reuse the collection/session resolution pattern from `TranslateQuery<TSource>` (`:188-214`). For the filter, apply the **Spike 0A** result.
+
+- [ ] **Step 1: Add `VisitExtension` override and the delete executor**
+
+Add to `MongoShapedQueryCompilingExpressionVisitor`:
+
+```csharp
+#if !EF8
+    protected override Expression VisitExtension(Expression extensionExpression)
+        => extensionExpression is MongoNonQueryExpression nonQuery
+            ? VisitNonQuery(nonQuery)
+            : base.VisitExtension(extensionExpression);
+
+    private Expression VisitNonQuery(MongoNonQueryExpression nonQuery)
+    {
+        var entityType = nonQuery.SourceQuery.CollectionExpression.EntityType;
+        var executor = QueryCompilationContext.IsAsync
+            ? (nonQuery.Kind == MongoNonQueryExpression.OperationKind.Delete
+                ? ExecuteDeleteAsyncMethodInfo : ExecuteUpdateAsyncMethodInfo)
+            : (nonQuery.Kind == MongoNonQueryExpression.OperationKind.Delete
+                ? ExecuteDeleteMethodInfo : ExecuteUpdateMethodInfo);
+
+        return Expression.Call(null,
+            executor.MakeGenericMethod(entityType.ClrType),
+            QueryCompilationContext.QueryContextParameter,
+            Expression.Constant(entityType),
+            Expression.Constant(_bsonSerializerFactory),
+            Expression.Constant(nonQuery));
+    }
+
+    private static int ExecuteDelete<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var (collection, session, filter, logger) =
+            PrepareBulk<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+
+        // logger.ExecutingBulkDelete(...);  // add a diagnostics event in Task 7
+        var result = session == null
+            ? collection.DeleteMany(filter)
+            : collection.DeleteMany(session, filter);
+        return checked((int)result.DeletedCount);
+    }
+
+    private static async Task<int> ExecuteDeleteAsync<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var (collection, session, filter, _) =
+            PrepareBulk<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+
+        var ct = queryContext.CancellationToken;
+        var result = session == null
+            ? await collection.DeleteManyAsync(filter, ct).ConfigureAwait(false)
+            : await collection.DeleteManyAsync(session, filter, options: null, ct).ConfigureAwait(false);
+        return checked((int)result.DeletedCount);
+    }
+```
+
+Add the shared preparation helper. **The body of `BuildFilter` is the Spike 0A result** — the snippet below is the expected shape; reconcile the `Render` call and predicate extraction with the recorded spike decision:
+
+```csharp
+    private static (IMongoCollection<BsonDocument> collection,
+                    IClientSessionHandle? session,
+                    FilterDefinition<BsonDocument> filter,
+                    MongoQueryContext context)
+        PrepareBulk<TSource>(
+            QueryContext queryContext,
+            IReadOnlyEntityType entityType,
+            BsonSerializerFactory bsonSerializerFactory,
+            MongoNonQueryExpression nonQuery)
+    {
+        var mongoQueryContext = (MongoQueryContext)queryContext;
+        var collectionName = nonQuery.SourceQuery.CollectionExpression.CollectionName;
+        var collection = mongoQueryContext.MongoClient.GetCollection<BsonDocument>(collectionName);
+        var session = (mongoQueryContext.Context.Database.CurrentTransaction as MongoTransaction)?.Session;
+
+        var filter = BuildFilter<TSource>(mongoQueryContext, entityType, bsonSerializerFactory, nonQuery.SourceQuery);
+        return (collection, session, filter, mongoQueryContext);
+    }
+
+    // === Spike 0A result goes here ===
+    // Expected shape (confirm Render overload + predicate extraction against driver 3.9.0):
+    private static FilterDefinition<BsonDocument> BuildFilter<TSource>(
+        MongoQueryContext mongoQueryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoQueryExpression sourceQuery)
+    {
+        var serializer = (IBsonSerializer<TSource>)bsonSerializerFactory.GetEntitySerializer((IEntityType)entityType);
+
+        // No predicate => match everything.
+        if (sourceQuery.CapturedExpression == null)
+        {
+            return FilterDefinition<BsonDocument>.Empty;
+        }
+
+        // Translate the captured Where chain into a single Expression<Func<TSource,bool>> in
+        // driver-LINQ terms via MongoEFToLinqTranslatingExpressionVisitor (see Spike 0A for the
+        // exact extraction + combination of multiple Where lambdas under one parameter), then:
+        //   var efFilter = new ExpressionFilterDefinition<TSource>(predicate);
+        //   var rendered = efFilter.Render(new RenderArgs<TSource>(serializer, BsonSerializer.SerializerRegistry));
+        //   return new BsonDocumentFilterDefinition<BsonDocument>(rendered);
+        throw new System.NotImplementedException("Replace with Spike 0A result.");
+    }
+
+    private static readonly MethodInfo ExecuteDeleteMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor).GetTypeInfo()
+            .DeclaredMethods.Single(m => m.Name == nameof(ExecuteDelete));
+    private static readonly MethodInfo ExecuteDeleteAsyncMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor).GetTypeInfo()
+            .DeclaredMethods.Single(m => m.Name == nameof(ExecuteDeleteAsync));
+    // ExecuteUpdateMethodInfo / ExecuteUpdateAsyncMethodInfo added in Task 6.
+#endif
+```
+
+Add required `using`s: `System.Threading.Tasks`, and confirm `Microsoft.EntityFrameworkCore.Metadata` (`IEntityType`) is imported.
+
+- [ ] **Step 2: Reconcile `BuildFilter` with the Spike 0A decision**
+
+Replace the `NotImplementedException` body with the spike-validated rendering + predicate-extraction code. Remove the `ExecuteUpdate*` `MethodInfo` references for now (or add the methods as stubs) so it compiles — simplest is to add Task 6's methods now if you prefer, but the plan keeps delete shippable on its own; temporarily comment the two update `MethodInfo` fields and the update branch in `VisitNonQuery` until Task 6.
+
+- [ ] **Step 3: Build EF9/EF10**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF9"` / `-c "Debug EF10"`
+Expected: succeed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+git commit -m "EF-NNN: Execute server-side deleteMany for ExecuteDelete"
+```
+
+### Task 5: ExecuteDelete behavior tests (functional, real DB)
+
+**Files:**
+- Create: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs`
+
+- [ ] **Step 1: Write failing functional tests**
+
+Follow the existing functional-test fixture pattern (seed via `TemporaryDatabaseFixture`/the project's standard setup — copy the structure from a neighboring file in `tests/.../FunctionalTests/Query/`). Tests:
+
+```csharp
+#if !EF8
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+public class ExecuteDeleteTests   // : a base/fixture matching the project's convention
+{
+    [Fact]
+    public void ExecuteDelete_with_predicate_deletes_matching_and_returns_count()
+    {
+        // seed N docs; M match predicate
+        using var db = /* create context over a uniquely-named database, seed data */;
+        var deleted = db.Set<Customer>().Where(c => c.Region == "WA").ExecuteDelete();
+        deleted.Should().Be(/* M */);
+        db.Set<Customer>().Count(c => c.Region == "WA").Should().Be(0);
+        db.Set<Customer>().Count().Should().Be(/* N - M */);
+    }
+
+    [Fact]
+    public async Task ExecuteDeleteAsync_deletes_matching()
+    {
+        using var db = /* ... */;
+        var deleted = await db.Set<Customer>().Where(c => c.Region == "WA").ExecuteDeleteAsync();
+        deleted.Should().Be(/* M */);
+    }
+
+    [Fact]
+    public void ExecuteDelete_with_ordering_throws_translation_failure()
+    {
+        using var db = /* ... */;
+        var act = () => db.Set<Customer>().OrderBy(c => c.Name).ExecuteDelete();
+        act.Should().Throw<InvalidOperationException>();
+    }
+}
+#endif
+```
+
+Use a real mapped entity from the functional-test models (replace `Customer`/`Region`/`Name`).
+
+- [ ] **Step 2: Run to verify they fail (then pass after build)**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF9"` then
+`dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF9" --no-build --filter "FullyQualifiedName~ExecuteDeleteTests"`
+Expected: the delete tests PASS (Task 4 implemented them); the ordering test PASSES (asserts the throw). If a delete test fails, debug `BuildFilter` rendering against Spike 0A.
+
+- [ ] **Step 3: Run the same under EF10**
+
+Run: `... -c "Debug EF10" ...`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs
+git commit -m "EF-NNN: ExecuteDelete functional tests"
+```
+
+---
+
+## Phase 3 — ExecuteUpdate with constant/parameter setters
+
+### Task 6: `TranslateExecuteUpdate` (EF9 + EF10 signature split) and constant-`$set` executor
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs`
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs`
+
+- [ ] **Step 1: Add the version-split override**
+
+In `MongoQueryableMethodTranslatingExpressionVisitor`:
+
+```csharp
+#if EF10
+    protected override Expression? TranslateExecuteUpdate(
+        ShapedQueryExpression source,
+        IReadOnlyList<ExecuteUpdateSetter> setters)
+    {
+        var mongoQueryExpression = (MongoQueryExpression)source.QueryExpression;
+        ValidateBulkSource(mongoQueryExpression);
+        var parsed = setters
+            .Select(s => BuildSetter(mongoQueryExpression, s.PropertySelector, s.ValueExpression))
+            .ToList();
+        return new MongoNonQueryExpression(mongoQueryExpression, parsed);
+    }
+#elif EF9
+    protected override Expression? TranslateExecuteUpdate(
+        ShapedQueryExpression source,
+        LambdaExpression setPropertyCalls)
+    {
+        var mongoQueryExpression = (MongoQueryExpression)source.QueryExpression;
+        ValidateBulkSource(mongoQueryExpression);
+        var parsed = new List<MongoNonQueryExpression.Setter>();
+        // Walk the chained SetPropertyCalls: ((SetPropertyCalls<T> c) => c.SetProperty(sel, val).SetProperty(...))
+        var body = setPropertyCalls.Body;
+        while (body is MethodCallExpression { Method.Name: "SetProperty" } call)
+        {
+            var selector = call.Arguments[0].UnwrapLambdaFromQuote();
+            var value = call.Arguments[1];                      // may be a value or a lambda (self-referencing)
+            parsed.Insert(0, BuildSetter(mongoQueryExpression, selector, value));
+            body = call.Object!;
+        }
+        return new MongoNonQueryExpression(mongoQueryExpression, parsed);
+    }
+#endif
+```
+
+Add the shared setter-builder that resolves the target `IProperty` and classifies the value:
+
+```csharp
+#if !EF8
+    private MongoNonQueryExpression.Setter BuildSetter(
+        MongoQueryExpression mongoQueryExpression,
+        LambdaExpression propertySelector,
+        Expression valueExpression)
+    {
+        var entityType = mongoQueryExpression.CollectionExpression.EntityType;
+        // propertySelector is e => e.SomeScalar ; resolve to an IProperty (root scalar only).
+        var member = (propertySelector.Body as MemberExpression)
+            ?? (propertySelector.Body is UnaryExpression { Operand: MemberExpression m } ? m : null);
+        var property = member is null ? null : entityType.FindProperty(member.Member.Name);
+        if (property == null)
+        {
+            AddTranslationErrorDetails(
+                "ExecuteUpdate setters must target a mapped root scalar property of the entity.");
+            throw new InvalidOperationException(
+                CoreStrings.NonQueryTranslationFailedWithDetails(
+                    mongoQueryExpression.CapturedExpression?.Print(), TranslationErrorDetails));
+        }
+
+        // Self-referencing when the value is a lambda referencing the entity parameter
+        // (EF9 passes Func<T,TProp>; EF10 passes a plain value Expression for constants and a
+        // parameter-referencing Expression for computed values — see Spike 0B / EF10 setter parsing).
+        var isSelfReferencing = ValueReferencesEntity(valueExpression, propertySelector.Parameters);
+        return new MongoNonQueryExpression.Setter(property, valueExpression, isSelfReferencing);
+    }
+
+    private static bool ValueReferencesEntity(Expression value, IReadOnlyList<ParameterExpression> entityParams)
+    {
+        var found = false;
+        var finder = new ParameterFinder(entityParams, () => found = true);
+        finder.Visit(value);
+        return found;
+    }
+
+    private sealed class ParameterFinder(IReadOnlyList<ParameterExpression> targets, System.Action onFound)
+        : System.Linq.Expressions.ExpressionVisitor
+    {
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            if (targets.Contains(node)) onFound();
+            return base.VisitParameter(node);
+        }
+    }
+#endif
+```
+
+> Note: confirm the exact EF9 `SetProperty` argument layout (selector at `[0]`, value at `[1]`) and the EF10 `ExecuteUpdateSetter` value normalization (a `Convert`-to-`object` wrapper is stripped by EF) during build, per Task 0/the EF source findings.
+
+- [ ] **Step 2: Add the update executor (constant path) in the compiling visitor**
+
+In `MongoShapedQueryCompilingExpressionVisitor`, add `ExecuteUpdate`/`ExecuteUpdateAsync` mirroring `ExecuteDelete`, and the `MethodInfo` fields referenced by `VisitNonQuery`. Build the update from setters:
+
+```csharp
+    private static int ExecuteUpdate<TSource>(
+        QueryContext queryContext, IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory, MongoNonQueryExpression nonQuery)
+    {
+        var (collection, session, filter, _) =
+            PrepareBulk<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+        var update = BuildUpdate<TSource>((MongoQueryContext)queryContext, entityType, bsonSerializerFactory, nonQuery);
+        var result = session == null
+            ? collection.UpdateMany(filter, update)
+            : collection.UpdateMany(session, filter, update);
+        return checked((int)result.ModifiedCount);
+    }
+
+    private static async Task<int> ExecuteUpdateAsync<TSource>(
+        QueryContext queryContext, IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory, MongoNonQueryExpression nonQuery)
+    {
+        var (collection, session, filter, _) =
+            PrepareBulk<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+        var update = BuildUpdate<TSource>((MongoQueryContext)queryContext, entityType, bsonSerializerFactory, nonQuery);
+        var ct = queryContext.CancellationToken;
+        var result = session == null
+            ? await collection.UpdateManyAsync(filter, update, options: null, ct).ConfigureAwait(false)
+            : await collection.UpdateManyAsync(session, filter, update, options: null, ct).ConfigureAwait(false);
+        return checked((int)result.ModifiedCount);
+    }
+
+    private static UpdateDefinition<BsonDocument> BuildUpdate<TSource>(
+        MongoQueryContext mongoQueryContext, IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory, MongoNonQueryExpression nonQuery)
+    {
+        if (nonQuery.Setters.Any(s => s.IsSelfReferencing))
+        {
+            return BuildPipelineUpdate<TSource>(mongoQueryContext, entityType, bsonSerializerFactory, nonQuery); // Task 8 / Spike 0B
+        }
+
+        // Constant/parameter $set path: serialize each value via the property serializer (same as MongoUpdate).
+        var setDoc = new BsonDocument();
+        foreach (var setter in nonQuery.Setters)
+        {
+            var elementName = setter.Property.GetElementName();
+            var value = EvaluateConstant(mongoQueryContext, setter.ValueExpression);
+            setDoc[elementName] = SerializePropertyValue(setter.Property, value);  // mirror MongoUpdate.WriteProperty
+        }
+        return new BsonDocumentUpdateDefinition<BsonDocument>(new BsonDocument("$set", setDoc));
+    }
+```
+
+For `EvaluateConstant` reuse the parameter/closure evaluation pattern already in `MongoEFToLinqTranslatingExpressionVisitor.TryEvaluateToConstant` (`:657-694`) — extract a small shared helper or replicate the constant/closure/query-parameter cases. For `SerializePropertyValue`, mirror how `MongoUpdate.WriteProperty` (`Storage/MongoUpdate.cs:204`) serializes a property value to a `BsonValue` via `BsonSerializerFactory.GetPropertySerializationInfo(property)`. Add `BuildPipelineUpdate` as a `throw new NotImplementedException("Task 8")` stub for now.
+
+- [ ] **Step 3: Build EF9/EF10**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF9"` / `-c "Debug EF10"`
+Expected: succeed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+git commit -m "EF-NNN: TranslateExecuteUpdate + constant \$set executor"
+```
+
+### Task 7: ExecuteUpdate (constant) behavior tests + diagnostics events
+
+**Files:**
+- Create: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateTests.cs`
+- Modify: `src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerUpdateExtensions.cs` and `Diagnostics/MongoEventId.cs` (add `ExecutingBulkDelete`/`ExecutingBulkUpdate` events mirroring the existing `ExecutingBulkWrite` event), then call them from the executors.
+
+- [ ] **Step 1: Write failing functional tests**
+
+```csharp
+#if !EF8
+[Fact]
+public void ExecuteUpdate_sets_constant_and_returns_count()
+{
+    using var db = /* seed */;
+    var updated = db.Set<Customer>().Where(c => c.Region == "WA")
+        .ExecuteUpdate(s => s.SetProperty(c => c.Region, "PNW"));
+    updated.Should().Be(/* M */);
+    db.Set<Customer>().Count(c => c.Region == "PNW").Should().Be(/* M */);
+}
+
+[Fact]
+public void ExecuteUpdate_sets_parameter_value()
+{
+    var newRegion = "PNW";
+    using var db = /* seed */;
+    db.Set<Customer>().Where(c => c.Region == "WA")
+        .ExecuteUpdate(s => s.SetProperty(c => c.Region, newRegion));
+    db.Set<Customer>().Count(c => c.Region == "PNW").Should().Be(/* M */);
+}
+#endif
+```
+
+- [ ] **Step 2: Run, debug to green (EF9 then EF10)**
+
+Run: `dotnet test ... -c "Debug EF9" --no-build --filter "FullyQualifiedName~ExecuteUpdateTests"` then EF10.
+Expected: PASS. If the `$set` value serialization is wrong (e.g. enum/Guid representation), align `SerializePropertyValue` with `MongoUpdate`.
+
+- [ ] **Step 3: Add diagnostics events and wire them into the executors**
+
+Mirror `ExecutingBulkWrite`/`ExecutedBulkWrite` in `MongoLoggerUpdateExtensions.cs` for delete/update bulk ops; register IDs in `MongoEventId`. Call them from `ExecuteDelete*/ExecuteUpdate*`. (Run the diagnostics-reviewer mentally: event IDs are stable/append-only.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateTests.cs src/MongoDB.EntityFrameworkCore/Diagnostics/
+git commit -m "EF-NNN: ExecuteUpdate constant setters + bulk diagnostics events"
+```
+
+---
+
+## Phase 4 — Self-referencing setters (pipeline updates)
+
+### Task 8: `BuildPipelineUpdate` (consumes Spike 0B)
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs`
+- Create: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateSelfReferencingTests.cs`
+
+> If Spike 0B selected the **constants-only fallback**, replace this task with: make `BuildPipelineUpdate` throw the canonical translation-failure for self-referencing setters, add a test asserting that throw, and file a fast-follow ticket. Skip the rest of Task 8.
+
+- [ ] **Step 1: Write failing functional test**
+
+```csharp
+#if !EF8
+[Fact]
+public void ExecuteUpdate_increments_self_referencing_value()
+{
+    using var db = /* seed: Orders with Quantity values */;
+    var updated = db.Set<Order>().Where(o => o.Status == "open")
+        .ExecuteUpdate(s => s.SetProperty(o => o.Quantity, o => o.Quantity + 1));
+    updated.Should().Be(/* M */);
+    // assert each matched order's Quantity increased by 1
+}
+#endif
+```
+
+- [ ] **Step 2: Implement `BuildPipelineUpdate` from the Spike 0B decision**
+
+Render each self-referencing setter's value expression to an aggregation-expression `BsonValue` (with EF element names) and assemble `Builders<BsonDocument>.Update.Pipeline([{ $set: { <element>: <renderedExpr> } }])`. Constant setters in the same call go into the same `$set` stage as literals. Use the exact rendering API recorded in Spike 0B.
+
+- [ ] **Step 3: Run to green (EF9 then EF10)**
+
+Run: `dotnet test ... --filter "FullyQualifiedName~ExecuteUpdateSelfReferencingTests"` under both configs.
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateSelfReferencingTests.cs
+git commit -m "EF-NNN: Self-referencing ExecuteUpdate via pipeline update"
+```
+
+---
+
+## Phase 5 — Spec conformance, EF8 boundary, cleanup
+
+### Task 9: Wire up EF Core `BulkUpdates` specification tests + EF8 boundary + cleanup
+
+**Files:**
+- Create: spec override classes under `tests/MongoDB.EntityFrameworkCore.SpecificationTests/` following the existing override-and-assert pattern (find EF Core's `BulkUpdates` test bases via the Specification.Tests package; mirror how a neighboring `Northwind*MongoTest` wires a base).
+- Create: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateDeleteEf8Tests.cs` (EF8 boundary).
+- Delete: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateDeleteSpikeTests.cs`.
+
+- [ ] **Step 1: Add the EF8 boundary test**
+
+```csharp
+#if EF8
+// On EF8, ExecuteDelete/ExecuteUpdate live in EFCore.Relational which this provider does not
+// reference, so the APIs are not available. This test documents the intentional boundary.
+// (If the extension methods are not even resolvable, this file may instead be a comment-only
+// marker; confirm during build.)
+#endif
+```
+
+If the methods aren't resolvable at all on EF8, document the boundary in `README.md`/`BREAKING-CHANGES.md` notes instead and skip the test file.
+
+- [ ] **Step 2: Add `BulkUpdates` spec overrides; annotate unsupported shapes**
+
+Override the EF Core bulk-update specification base. For shapes the provider doesn't support (cross-collection predicates, ordering/paging, owned-navigation setters), assert the translation failure and tag with `// Fails: <desc> EF-NNN` per `docs/failing-spec-tests.md` conventions. Update `docs/failing-spec-tests.md` with any new tickets.
+
+- [ ] **Step 3: Delete the spike test file**
+
+```bash
+git rm tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateDeleteSpikeTests.cs
+```
+
+- [ ] **Step 4: Run the full query + spec suites for all three EF versions**
+
+Use the `/test-all` skill (builds + tests EF8/EF9/EF10 in parallel), or:
+`dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF9" --filter "FullyQualifiedName~Execute|FullyQualifiedName~BulkUpdates"` (repeat EF10; EF8 confirms the feature is absent and nothing else broke).
+Expected: all PASS.
+
+- [ ] **Step 5: Update README "Limitations"**
+
+Remove "ExecuteUpdate & ExecuteDelete bulk operations (EF 9+)" from the *Planned for future releases* list in `README.md` (and add a line to *Supported Features* noting EF9+ bulk `ExecuteUpdate`/`ExecuteDelete`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/ docs/failing-spec-tests.md README.md
+git commit -m "EF-NNN: BulkUpdates spec conformance, EF8 boundary, docs"
+```
+
+### Task 10: Branch review
+
+- [ ] **Step 1: Run the provider's review skill**
+
+Invoke `/review-ef-core-provider` (it fans out the area reviewers — query, storage, diagnostics, api-stability, ef-conformance). Address findings. The `ef-conformance-reviewer` is especially relevant for the EF9-vs-EF10 signature split and the `#if !EF8` discipline; `api-stability-reviewer` confirms no public-surface break.
+
+- [ ] **Step 2: Final full test pass via `/test-all`, then open PR**
+
+Only push/PR when the user asks.
+
+---
+
+## Self-Review (performed against the spec)
+
+- **Spec §Scope (in):** ExecuteDelete/ExecuteUpdate sync+async → Tasks 3–8. ✓
+- **Spec §Scope (out → throw):** non-filter source shapes → `ValidateBulkSource` (Task 3); owned/non-scalar setters → `BuildSetter` guard (Task 6); spec overrides assert failures (Task 9). ✓
+- **Spec: EF9+EF10 only, `#if !EF8`, signature split:** Tasks 2,3,6 all `#if !EF8`; Task 6 `#if EF10/#elif EF9`. ✓
+- **Spec: constants/params via `$set`, self-ref via pipeline:** Task 6 (`$set`), Task 8 + Spike 0B (pipeline). ✓
+- **Spec: TPH discriminator preserved in filter:** captured chain includes it; `ValidateBulkSource` passes `Where`; verify in Task 5. ✓
+- **Spec: transactions match relational:** `PrepareBulk` threads `CurrentTransaction.Session` else null; no implicit txn (Task 4). ✓
+- **Spec: bypass change tracker / no concurrency check:** inherent — executor never touches the state manager. ✓
+- **Spec: return int (cast from long):** `checked((int)result.DeletedCount/ModifiedCount)` (Tasks 4,6). ✓
+- **Spec: no new public API:** confirmed — only EF's existing extension methods; verified by api-stability-reviewer (Task 10). ✓
+- **Spec §Risks: self-ref rendering spike + fallback:** Spike 0B with explicit fallback branch in Task 8. ✓
+- **Spec §Risks: filter typing:** Spike 0A. ✓
+- **Spec §Risks: int overflow:** `checked` cast surfaces it rather than silently wrapping (matches "documented, not guarded" intent; switch to unchecked if exact relational parity is preferred — note for reviewer). ✓
+
+**Placeholder scan:** the only `NotImplementedException`s are deliberate, named hand-offs between sequential tasks (Task 4→reconcile, Task 6→Task 8) and are removed within the same phase. The two spike-dependent bodies (`BuildFilter`, `BuildPipelineUpdate`) are explicitly gated on Phase 0 outputs. No silent TBDs.
+
+**Type consistency:** `MongoNonQueryExpression` / `.Setter` / `.OperationKind` used identically across Tasks 1,3,4,6,8. Executor `MethodInfo` names (`ExecuteDelete`/`ExecuteDeleteAsync`/`ExecuteUpdate`/`ExecuteUpdateAsync`) consistent between definition and reflection lookup. `PrepareBulk`/`BuildFilter`/`BuildUpdate`/`BuildPipelineUpdate` signatures consistent across tasks.

--- a/docs/superpowers/plans/2026-06-11-bulk-two-phase-execute-update-delete.md
+++ b/docs/superpowers/plans/2026-06-11-bulk-two-phase-execute-update-delete.md
@@ -1,0 +1,1183 @@
+# Two-phase `ExecuteUpdate` / `ExecuteDelete` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let bulk `ExecuteDelete`/`ExecuteUpdate` accept sources that combine `Where` with `OrderBy`/`ThenBy`/`Skip`/`Take`/`Distinct`, by querying the target `_id`s (phase 1) and acting on them via `{ _id: { $in: … } }` (phase 2), both inside one transaction.
+
+**Architecture:** Translate-time, a classifier tags the `MongoNonQueryExpression` as `SingleCommand` (the existing `Where`-only atomic path, unchanged) or `TwoPhase`. Execute-time, the `TwoPhase` path runs a key-projection read through the existing driver-LINQ machinery, then a `deleteMany`/`updateMany` filtered by the collected ids, wrapped in the ambient transaction or an auto-started one. Both phases share the session via `Database.CurrentTransaction`.
+
+**Tech Stack:** C# / .NET (net8.0 for EF8/EF9, net10.0 for EF10), EF Core provider internals, MongoDB C# driver LINQ v3, xUnit + FluentAssertions. All new behavior is under `#if !EF8` (EF9/EF10 only).
+
+**Design doc:** `docs/superpowers/specs/2026-06-11-bulk-two-phase-execute-update-delete-design.md`
+
+**Conventions reminder:**
+- Preserve file BOMs. `<Nullable>enable</Nullable>` on `src/` — annotate new types.
+- Build one EF version: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF10"` (or `EF9`/`EF8`).
+- Run one test class: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --no-build --filter "FullyQualifiedName~ClassName"`.
+- The local test server (atlas-local / replica set) supports multi-document transactions, so the two-phase path runs end-to-end in tests.
+- Commit messages start with `EF-107:`.
+
+---
+
+## Task 1: Add `BulkStrategy` to the marker node
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoNonQueryExpression.cs`
+- Test: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoNonQueryExpressionTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `MongoNonQueryExpressionTests` (mirror the existing test style in that file — it constructs a `MongoQueryExpression` already; reuse that helper/fixture):
+
+```csharp
+[Fact]
+public void Delete_marker_defaults_to_SingleCommand_strategy()
+{
+    var sourceQuery = CreateSourceQuery(); // existing helper in this test file
+    var node = new MongoNonQueryExpression(sourceQuery);
+
+    Assert.Equal(MongoNonQueryExpression.BulkStrategy.SingleCommand, node.Strategy);
+}
+
+[Fact]
+public void Delete_marker_carries_TwoPhase_strategy()
+{
+    var sourceQuery = CreateSourceQuery();
+    var node = new MongoNonQueryExpression(sourceQuery, MongoNonQueryExpression.BulkStrategy.TwoPhase);
+
+    Assert.Equal(MongoNonQueryExpression.BulkStrategy.TwoPhase, node.Strategy);
+}
+
+[Fact]
+public void Update_marker_carries_TwoPhase_strategy()
+{
+    var sourceQuery = CreateSourceQuery();
+    var setters = new List<MongoNonQueryExpression.Setter>();
+    var node = new MongoNonQueryExpression(sourceQuery, setters, MongoNonQueryExpression.BulkStrategy.TwoPhase);
+
+    Assert.Equal(MongoNonQueryExpression.BulkStrategy.TwoPhase, node.Strategy);
+    Assert.Equal(MongoNonQueryExpression.OperationKind.Update, node.Kind);
+}
+```
+
+> If `CreateSourceQuery()` doesn't exist in the test file, look at how the existing tests obtain a `MongoQueryExpression` and reuse that exact construction; do not invent a new fixture.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~MongoNonQueryExpressionTests"`
+Expected: FAIL — `BulkStrategy` / `Strategy` do not exist (compile error).
+
+- [ ] **Step 3: Add the enum and property**
+
+In `MongoNonQueryExpression.cs`, add the enum next to `OperationKind` and a `Strategy` property, and thread it through both constructors with a `SingleCommand` default:
+
+```csharp
+public enum OperationKind { Delete, Update }
+
+public enum BulkStrategy { SingleCommand, TwoPhase }
+
+public sealed record Setter(IProperty Property, Expression ValueExpression, bool IsSelfReferencing);
+
+public MongoNonQueryExpression(MongoQueryExpression sourceQuery, BulkStrategy strategy = BulkStrategy.SingleCommand)
+{
+    SourceQuery = sourceQuery;
+    Kind = OperationKind.Delete;
+    Setters = [];
+    Strategy = strategy;
+}
+
+public MongoNonQueryExpression(
+    MongoQueryExpression sourceQuery,
+    IReadOnlyList<Setter> setters,
+    BulkStrategy strategy = BulkStrategy.SingleCommand)
+{
+    SourceQuery = sourceQuery;
+    Kind = OperationKind.Update;
+    Setters = setters;
+    Strategy = strategy;
+}
+
+public MongoQueryExpression SourceQuery { get; }
+public OperationKind Kind { get; }
+public IReadOnlyList<Setter> Setters { get; }
+public BulkStrategy Strategy { get; }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~MongoNonQueryExpressionTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoNonQueryExpression.cs \
+        tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoNonQueryExpressionTests.cs
+git commit -m "EF-107: Add BulkStrategy to MongoNonQueryExpression"
+```
+
+---
+
+## Task 2: Replace `ValidateBulkSource` with the `ClassifyBulkSource` classifier
+
+This task is a **behavior-preserving refactor**. It changes translate-time validation so ordering/paging/distinct shapes are *classified* `TwoPhase` instead of throwing — but a transitional guard in `VisitNonQuery` keeps the **observable** behavior identical (still the canonical "could not be translated" `InvalidOperationException`, raised at query-compile time) until two-phase execution is wired in Tasks 4–5. This is required for safety: without the guard, a `TwoPhase` marker would fall through to the single-command executor, whose `BuildFilter` walks **only** `Where` and would silently ignore `OrderBy`/`Take` — e.g. `OrderBy().Take(1).ExecuteDelete()` would delete *everything*. It is also required to keep the tree green: ~25 `NorthwindBulkUpdates` spec tests assert `"could not be translated"` for these shapes and aren't promoted until Task 8.
+
+**No new test** is added here — this is a refactor, so its verification is "every existing functional and spec bulk test stays green." The canonical message contains both the phrase `"could not be translated"` and the printed source expression (so the existing `Contains("OrderBy")` functional tests also stay green).
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs:191-403`
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs:72-88` (transitional guard)
+
+- [ ] **Step 1: Establish the green baseline**
+
+Run the full bulk suites (functional + spec) and confirm they pass *before* the change, so you can prove the refactor preserves behavior:
+`dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~ExecuteDeleteTests|FullyQualifiedName~ExecuteUpdateTests|FullyQualifiedName~NorthwindBulkUpdatesMongoTest"`
+Expected: PASS. Note the counts.
+
+- [ ] **Step 2: (no failing test — see task intro)**
+
+This task adds no new behavior, so there is no new failing test. Skip to Step 3.
+
+- [ ] **Step 3: Replace `ValidateBulkSource` with `ClassifyBulkSource`**
+
+In `MongoQueryableMethodTranslatingExpressionVisitor.cs`, replace the `ValidateBulkSource` method (currently lines ~378-402) with:
+
+```csharp
+/// <summary>
+/// Classifies the captured source chain of a bulk delete/update. A chain of only
+/// <see cref="Queryable.Where{TSource}(IQueryable{TSource},Expression{Func{TSource,bool}})"/> is the
+/// single-command atomic path. Adding <c>OrderBy</c>/<c>OrderByDescending</c>/<c>ThenBy</c>/
+/// <c>ThenByDescending</c>/<c>Skip</c>/<c>Take</c>/<c>Distinct</c> requires the two-phase
+/// (query target <c>_id</c>s, then act by <c>$in</c>) path. Any other operator is not expressible as
+/// a server-side bulk scope and produces EF's canonical non-query translation failure. A TPH
+/// discriminator filter rides along as a Where.
+/// </summary>
+private MongoNonQueryExpression.BulkStrategy ClassifyBulkSource(MongoQueryExpression mongoQueryExpression)
+{
+    var expression = MongoNonQueryExpression.UnwrapBulkOperator(mongoQueryExpression.CapturedExpression);
+    var strategy = MongoNonQueryExpression.BulkStrategy.SingleCommand;
+
+    // Descend through every method-call node in the source chain, terminating at the non-method
+    // query root. Reject anything that is not one of the supported scoping operators (declared on
+    // Queryable) so BuildFilter's "never silently drop a predicate" invariant holds and an operator
+    // the read path cannot translate can never reach phase 1.
+    while (expression is MethodCallExpression methodCallExpression)
+    {
+        if (methodCallExpression.Method.DeclaringType != typeof(Queryable))
+        {
+            ThrowBulkSourceNotSupported(mongoQueryExpression, methodCallExpression.Method.Name);
+        }
+
+        switch (methodCallExpression.Method.Name)
+        {
+            case nameof(Queryable.Where):
+                break;
+
+            case nameof(Queryable.OrderBy):
+            case nameof(Queryable.OrderByDescending):
+            case nameof(Queryable.ThenBy):
+            case nameof(Queryable.ThenByDescending):
+            case nameof(Queryable.Skip):
+            case nameof(Queryable.Take):
+            case nameof(Queryable.Distinct):
+                strategy = MongoNonQueryExpression.BulkStrategy.TwoPhase;
+                break;
+
+            default:
+                ThrowBulkSourceNotSupported(mongoQueryExpression, methodCallExpression.Method.Name);
+                break;
+        }
+
+        expression = methodCallExpression.Arguments[0];
+    }
+
+    return strategy;
+}
+
+[DoesNotReturn]
+private void ThrowBulkSourceNotSupported(MongoQueryExpression mongoQueryExpression, string operatorName)
+{
+    AddTranslationErrorDetails(
+        $"The '{operatorName}' operator is not supported in a bulk delete or update. Only 'Where' predicates "
+        + "and the 'OrderBy', 'OrderByDescending', 'ThenBy', 'ThenByDescending', 'Skip', 'Take', and 'Distinct' "
+        + "operators can scope a bulk operation.");
+    throw new InvalidOperationException(
+        CoreStrings.NonQueryTranslationFailedWithDetails(
+            mongoQueryExpression.CapturedExpression?.Print(), TranslationErrorDetails));
+}
+```
+
+Add `using System.Diagnostics.CodeAnalysis;` at the top of the file if not already present (for `[DoesNotReturn]`).
+
+- [ ] **Step 4: Pass the classified strategy into the markers**
+
+In the same file, update the three translate methods to call `ClassifyBulkSource` and pass the result:
+
+`TranslateExecuteDelete` (~line 191):
+```csharp
+protected override Expression? TranslateExecuteDelete(ShapedQueryExpression source)
+{
+    var mongoQueryExpression = (MongoQueryExpression)source.QueryExpression;
+    var strategy = ClassifyBulkSource(mongoQueryExpression);
+    return new MongoNonQueryExpression(mongoQueryExpression, strategy);
+}
+```
+
+EF10 `TranslateExecuteUpdate` (~line 199):
+```csharp
+var mongoQueryExpression = (MongoQueryExpression)source.QueryExpression;
+var strategy = ClassifyBulkSource(mongoQueryExpression);
+var parsed = setters
+    .Select(s => BuildSetter(mongoQueryExpression, s.PropertySelector, s.ValueExpression))
+    .ToList();
+return new MongoNonQueryExpression(mongoQueryExpression, parsed, strategy);
+```
+
+EF9 `TranslateExecuteUpdate` (~line 211): change `ValidateBulkSource(mongoQueryExpression);` to `var strategy = ClassifyBulkSource(mongoQueryExpression);`, keep the empty-setter guard exactly as-is, and change the final return to:
+```csharp
+return new MongoNonQueryExpression(mongoQueryExpression, parsed, strategy);
+```
+
+- [ ] **Step 5: Add the transitional canonical-error guard in execution**
+
+In `MongoShapedQueryCompilingExpressionVisitor.cs`, in `VisitNonQuery` (~line 72), add at the top of the method a guard that throws the **same canonical translation failure** the translate step used to throw (so observable behavior is unchanged), raised here at compile-time:
+
+```csharp
+private Expression VisitNonQuery(MongoNonQueryExpression nonQueryExpression)
+{
+    if (nonQueryExpression.Strategy == MongoNonQueryExpression.BulkStrategy.TwoPhase)
+    {
+        // Transitional: two-phase execution is wired in Tasks 4 (delete) / 5 (update). Until then,
+        // preserve the pre-refactor behavior — reject these shapes with EF's canonical non-query
+        // translation failure — rather than letting a TwoPhase marker fall through to the single-
+        // command executor (whose filter ignores OrderBy/Skip/Take/Distinct and would act on the
+        // wrong document set).
+        throw new InvalidOperationException(
+            CoreStrings.NonQueryTranslationFailedWithDetails(
+                nonQueryExpression.SourceQuery.CapturedExpression?.Print(),
+                "ordering, paging, and 'Distinct' in a bulk delete or update are not yet supported."));
+    }
+
+    var entityType = nonQueryExpression.SourceQuery.CollectionExpression.EntityType;
+    // ... unchanged existing body ...
+```
+
+Add `using Microsoft.EntityFrameworkCore.Diagnostics;` / the `using` that exposes `CoreStrings` if the file doesn't already have it (the translate visitor uses `CoreStrings`; match its using). `Expression.Print()` is an EF extension already available where `CapturedExpression` is used.
+
+- [ ] **Step 6: Verify the full bulk suite is still green (behavior preserved)**
+
+Run the same filter as Step 1:
+`dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~ExecuteDeleteTests|FullyQualifiedName~ExecuteUpdateTests|FullyQualifiedName~NorthwindBulkUpdatesMongoTest"`
+Expected: PASS — identical counts to Step 1. The existing `*_after_OrderBy_throws` functional tests (assert `Contains("OrderBy")`) and the spec `AssertTranslationFailed` cases (assert `"could not be translated"`) all still pass because the canonical message contains both. **Do not modify any existing test in this task** — if one fails, the guard message is wrong, not the test.
+
+- [ ] **Step 7: Confirm it compiles on EF9 and EF8**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF9"` and `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF8"`.
+Expected: both succeed (on EF8 the whole bulk region is excluded by `#if !EF8`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs \
+        src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+git commit -m "EF-107: Classify bulk sources as single-command or two-phase"
+```
+
+---
+
+## Task 3: Phase-1 helper — project and collect target `_id`s
+
+Add the strongly-typed phase-1 reader. It is generic on `<TSource, TKey>` so the driver calls stay typed; the executor (Task 4) computes `TKey` from the entity's single-property primary key and dispatches via `MakeGenericMethod`. This task validates phase 1 in isolation with a temporary test, then leaves the helper in place.
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs` (add helpers near the other bulk executors, after `PrepareBulk`)
+- Test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs` (temporary harness test, removed in Step 6)
+
+- [ ] **Step 1: Write the temporary validation test**
+
+This drives the helper through reflection (it is `internal`/`private static`; the functional test assembly has `InternalsVisibleTo`). It seeds three orders and asserts phase 1 returns the right `_id`s for `OrderBy(Quantity).Take(2)`, sync and async.
+
+```csharp
+[Fact]
+public async Task Phase1_collects_target_ids_sync_and_async()
+{
+    using var db = CreateSeededContext();
+    var entityType = db.Model.FindEntityType(typeof(Order))!;
+    var queryContext = GetQueryContext(db); // see note below
+    var factory = db.GetService<MongoDB.EntityFrameworkCore.Serializers.BsonSerializerFactory>();
+
+    // Build the MongoNonQueryExpression by translating a two-phase delete without executing it is
+    // non-trivial; instead validate the public end-to-end behavior is correct in Task 4. Here we only
+    // confirm the helper compiles and returns ObjectId BsonValues for a known ordered/paged source.
+    // (This temporary test is removed in Step 6.)
+    Assert.True(true);
+}
+```
+
+> Reaching the `QueryContext`/`MongoNonQueryExpression` from a functional test in isolation is awkward — phase 1 is most honestly validated end-to-end in Task 4. So this task's real verification is **Step 5 (build + the Task 4 acceptance test)**. Keep this placeholder test trivial and delete it in Step 6; do not invent private-state plumbing.
+
+- [ ] **Step 2: Add the key-shape guard and the `<TSource, TKey>` dispatch helper**
+
+In `MongoShapedQueryCompilingExpressionVisitor.cs`, inside the `#if !EF8` region, add:
+
+```csharp
+// Resolves the single-property primary key whose value the two-phase path projects (phase 1) and
+// filters on (phase 2). MongoDB maps the PK to a single _id field; composite/owned/shadow shapes that
+// can't form a simple member projection fall back to the canonical non-query failure.
+private static IProperty GetBulkKeyOrThrow(IReadOnlyEntityType entityType, MongoNonQueryExpression nonQuery)
+{
+    var key = entityType.FindPrimaryKey();
+    if (key is { Properties: [{ PropertyInfo: not null } keyProperty] })
+    {
+        return keyProperty;
+    }
+
+    throw new InvalidOperationException(
+        CoreStrings.NonQueryTranslationFailedWithDetails(
+            nonQuery.SourceQuery.CapturedExpression?.Print(),
+            "the entity's primary key must be a single mapped property to use ordering, paging, or Distinct "
+            + "in a bulk delete or update."));
+}
+```
+
+- [ ] **Step 3: Add the phase-1 reader (sync + async)**
+
+Add (these mirror the read path's `TranslateQuery` setup: build the driver `IQueryable<TSource>` from `collection.AsQueryable(session)`, wrap in the EF entity serializer, translate the captured chain — here with an extra key `Select`):
+
+```csharp
+// Phase 1: run the bulk source (Where + OrderBy/Skip/Take/Distinct) as a read projecting only the
+// primary key, on the ambient transaction session, and serialize each key to the BsonValue used by the
+// phase-2 { _id: { $in: ... } } filter. The driver translates the ordering/paging/distinct operators.
+private static List<BsonValue> SelectTargetIds<TSource, TKey>(
+    QueryContext queryContext,
+    IReadOnlyEntityType entityType,
+    BsonSerializerFactory bsonSerializerFactory,
+    MongoNonQueryExpression nonQuery,
+    IProperty keyProperty)
+{
+    var keyQuery = BuildKeyQuery<TSource, TKey>(queryContext, entityType, bsonSerializerFactory, nonQuery, keyProperty);
+    var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(keyProperty);
+
+    var ids = new List<BsonValue>();
+    foreach (var key in keyQuery)
+    {
+        ids.Add(serializationInfo.SerializeValue(key));
+    }
+
+    return ids;
+}
+
+private static async Task<List<BsonValue>> SelectTargetIdsAsync<TSource, TKey>(
+    QueryContext queryContext,
+    IReadOnlyEntityType entityType,
+    BsonSerializerFactory bsonSerializerFactory,
+    MongoNonQueryExpression nonQuery,
+    IProperty keyProperty)
+{
+    var keyQuery = BuildKeyQuery<TSource, TKey>(queryContext, entityType, bsonSerializerFactory, nonQuery, keyProperty);
+    var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(keyProperty);
+
+    var keys = await Driver.Linq.MongoQueryable
+        .ToListAsync(keyQuery, queryContext.CancellationToken).ConfigureAwait(false);
+
+    var ids = new List<BsonValue>(keys.Count);
+    foreach (var key in keys)
+    {
+        ids.Add(serializationInfo.SerializeValue(key));
+    }
+
+    return ids;
+}
+
+private static IQueryable<TKey> BuildKeyQuery<TSource, TKey>(
+    QueryContext queryContext,
+    IReadOnlyEntityType entityType,
+    BsonSerializerFactory bsonSerializerFactory,
+    MongoNonQueryExpression nonQuery,
+    IProperty keyProperty)
+{
+    var mongoQueryContext = (MongoQueryContext)queryContext;
+    var collection =
+        mongoQueryContext.MongoClient.GetCollection<TSource>(nonQuery.SourceQuery.CollectionExpression.CollectionName);
+    var session = (mongoQueryContext.Context.Database.CurrentTransaction as MongoTransaction)?.Session;
+    var queryable = session == null ? collection.AsQueryable() : collection.AsQueryable(session);
+    var source = queryable.As((IBsonSerializer<TSource>)bsonSerializerFactory.GetEntitySerializer(entityType));
+
+    var translator = new MongoEFToLinqTranslatingExpressionVisitor(queryContext, source.Expression, bsonSerializerFactory);
+
+    // Append Select(e => e.<key>) to the bulk source chain (minus the leading ExecuteDelete/Update marker).
+    var sourceChain = MongoNonQueryExpression.UnwrapBulkOperator(nonQuery.SourceQuery.CapturedExpression)!;
+    var parameter = Expression.Parameter(typeof(TSource), "e");
+    var keySelector = Expression.Lambda<Func<TSource, TKey>>(
+        Expression.MakeMemberAccess(parameter, keyProperty.PropertyInfo!), parameter);
+    var selectCall = Expression.Call(
+        QueryableMethods.Select.MakeGenericMethod(typeof(TSource), typeof(TKey)),
+        sourceChain,
+        Expression.Quote(keySelector));
+
+    var translated = translator.Visit(selectCall)!;
+    return source.Provider.CreateQuery<TKey>(translated);
+}
+```
+
+Add any missing `using`s the file doesn't already have: `using System;` (for `Func<>`), `using System.Collections.Generic;`, `using System.Linq;`, `using System.Linq.Expressions;`, `using Microsoft.EntityFrameworkCore.Metadata;`. The file already uses `MongoDB.Driver`, `MongoDB.Bson`, the EF→LINQ translator, and `QueryableMethods`.
+
+- [ ] **Step 4: Build to verify it compiles on all EF versions**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF10"`
+Then: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF9"` and `-c "Debug EF8"`.
+Expected: all succeed. (On EF8 the helpers are excluded by `#if !EF8`.)
+
+> If `Driver.Linq.MongoQueryable.ToListAsync` is not the correct async-materialization entry point for an `IQueryable<TKey>` produced by `IMongoQueryProvider.CreateQuery`, use the driver's `IAsyncCursorSourceExtensions.ToListAsync((IAsyncCursorSource<TKey>)keyQuery, cancellationToken)` instead — `keyQuery` is driver-backed and implements `IAsyncCursorSource<TKey>`. Confirm which compiles; both are MongoDB driver APIs.
+
+- [ ] **Step 5: Verify end-to-end happens in Task 4**
+
+The helper has no standalone behavioral test (see Step 1 note). Its correctness is asserted by Task 4's acceptance test.
+
+- [ ] **Step 6: Remove the placeholder test and commit**
+
+Delete the `Phase1_collects_target_ids_sync_and_async` placeholder added in Step 1.
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs \
+        tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs
+git commit -m "EF-107: Add phase-1 target-id projection helper for two-phase bulk"
+```
+
+---
+
+## Task 4: Wire two-phase `ExecuteDelete` (+ transaction scope)
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs`
+- Test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs`
+
+- [ ] **Step 1: Write the failing acceptance tests**
+
+Add the real two-phase delete behavior tests (Task 2 added no functional test — it was a behavior-preserving refactor):
+
+```csharp
+[Fact]
+public void ExecuteDelete_with_OrderBy_Take_deletes_lowest_quantities()
+{
+    using var db = CreateSeededContext(); // 3 orders: qty 10 (open), 20 (open), 30 (closed)
+
+    var deleted = db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDelete();
+
+    Assert.Equal(2, deleted);
+    var remaining = db.Entities.OrderBy(o => o.Quantity).ToList();
+    Assert.Single(remaining);
+    Assert.Equal(30, remaining[0].Quantity);
+}
+
+[Fact]
+public void ExecuteDelete_with_Where_and_Skip_Take_scopes_to_window()
+{
+    using var db = CreateSeededContext();
+
+    var deleted = db.Entities.Where(o => o.Status == "open").OrderBy(o => o.Quantity).Skip(1).Take(1).ExecuteDelete();
+
+    Assert.Equal(1, deleted);                 // only the qty=20 "open" row
+    Assert.Equal(2, db.Entities.Count());
+    Assert.DoesNotContain(db.Entities.ToList(), o => o.Quantity == 20);
+}
+
+[Fact]
+public void ExecuteDelete_two_phase_empty_target_returns_zero()
+{
+    using var db = CreateSeededContext();
+
+    var deleted = db.Entities.Where(o => o.Status == "nonexistent").OrderBy(o => o.Quantity).Take(5).ExecuteDelete();
+
+    Assert.Equal(0, deleted);
+    Assert.Equal(3, db.Entities.Count());
+}
+
+[Fact]
+public void ExecuteDelete_two_phase_rolls_back_inside_user_transaction()
+{
+    using var db = CreateSeededContext();
+    using (var tx = db.Database.BeginTransaction())
+    {
+        var deleted = db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDelete();
+        Assert.Equal(2, deleted);
+        tx.Rollback();
+    }
+
+    // Rolled back: nothing actually removed.
+    Assert.Equal(3, db.Entities.Count());
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~ExecuteDeleteTests.ExecuteDelete_with_OrderBy_Take_deletes_lowest_quantities"`
+Expected: FAIL — currently the transitional guard throws the canonical "could not be translated" error (the two-phase delete isn't wired yet), so the delete doesn't happen and the assertions fail.
+
+- [ ] **Step 3: Add the transaction-scope helpers**
+
+In `MongoShapedQueryCompilingExpressionVisitor.cs` (`#if !EF8` region) add:
+
+```csharp
+// Two-phase bulk needs phase 1 (read) and phase 2 (write) to observe one snapshot, so both run inside a
+// single transaction. If the user already opened one we join it (and never commit it — they own it);
+// otherwise we auto-start one, commit on success, abort on failure. AutoTransactionBehavior.Never means
+// "I manage transactions" — we refuse to auto-start and tell the caller to open one.
+private static int RunInBulkTransaction(QueryContext queryContext, MongoNonQueryExpression nonQuery, Func<int> body)
+{
+    var database = queryContext.Context.Database;
+    if (database.CurrentTransaction != null)
+    {
+        return body();
+    }
+
+    if (database.AutoTransactionBehavior == AutoTransactionBehavior.Never)
+    {
+        throw NoAutoTransactionError(nonQuery);
+    }
+
+    var transaction = database.BeginTransaction();
+    try
+    {
+        var result = body();
+        transaction.Commit();
+        return result;
+    }
+    catch (Exception exception)
+    {
+        SafeRollback(transaction);
+        if (IsTransactionsUnsupported(exception))
+        {
+            throw StandaloneTransactionError(nonQuery, exception);
+        }
+
+        throw;
+    }
+    finally
+    {
+        transaction.Dispose();
+    }
+}
+
+private static async Task<int> RunInBulkTransactionAsync(
+    QueryContext queryContext, MongoNonQueryExpression nonQuery, Func<Task<int>> body)
+{
+    var database = queryContext.Context.Database;
+    if (database.CurrentTransaction != null)
+    {
+        return await body().ConfigureAwait(false);
+    }
+
+    if (database.AutoTransactionBehavior == AutoTransactionBehavior.Never)
+    {
+        throw NoAutoTransactionError(nonQuery);
+    }
+
+    var cancellationToken = queryContext.CancellationToken;
+    var transaction = await database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+    try
+    {
+        var result = await body().ConfigureAwait(false);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+    catch (Exception exception)
+    {
+        await SafeRollbackAsync(transaction, cancellationToken).ConfigureAwait(false);
+        if (IsTransactionsUnsupported(exception))
+        {
+            throw StandaloneTransactionError(nonQuery, exception);
+        }
+
+        throw;
+    }
+    finally
+    {
+        await transaction.DisposeAsync().ConfigureAwait(false);
+    }
+}
+
+private static void SafeRollback(IDbContextTransaction transaction)
+{
+    try { transaction.Rollback(); }
+    catch { /* a failed/standalone transaction may not be rollback-able; the original error wins */ }
+}
+
+private static async Task SafeRollbackAsync(IDbContextTransaction transaction, CancellationToken cancellationToken)
+{
+    try { await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false); }
+    catch { /* see SafeRollback */ }
+}
+
+private static InvalidOperationException NoAutoTransactionError(MongoNonQueryExpression nonQuery)
+    => new(
+        "This bulk delete or update uses ordering, paging, or 'Distinct', which the MongoDB provider executes "
+        + "as a two-phase operation requiring a transaction. The context's AutoTransactionBehavior is 'Never', "
+        + "so open an explicit transaction (Database.BeginTransaction) around the call.");
+
+private static InvalidOperationException StandaloneTransactionError(MongoNonQueryExpression nonQuery, Exception inner)
+    => new(
+        "This bulk delete or update uses ordering, paging, or 'Distinct', which the MongoDB provider executes "
+        + "as a two-phase operation requiring a transaction. The current MongoDB deployment does not support "
+        + "multi-document transactions (a replica set or sharded cluster is required).", inner);
+
+// Multi-document transactions are rejected on standalone deployments; the driver surfaces this as a
+// MongoCommandException (code 20 / IllegalOperation) or an "Transaction numbers are only allowed on a
+// replica set member or mongos" message. Match conservatively so unrelated failures propagate untouched.
+private static bool IsTransactionsUnsupported(Exception exception)
+    => exception is MongoCommandException { Code: 20 }
+       || (exception is MongoException && exception.Message.Contains("Transaction numbers are only allowed", StringComparison.Ordinal));
+```
+
+Add `using Microsoft.EntityFrameworkCore.Storage;` (for `IDbContextTransaction`) and confirm `using Microsoft.EntityFrameworkCore;` is present (for `AutoTransactionBehavior`). `MongoCommandException`/`MongoException` come from `MongoDB.Driver` (already used).
+
+- [ ] **Step 4: Add the two-phase delete executors and dispatch**
+
+Add the executors:
+
+```csharp
+private static int ExecuteTwoPhaseDelete<TSource, TKey>(
+    QueryContext queryContext,
+    IReadOnlyEntityType entityType,
+    BsonSerializerFactory bsonSerializerFactory,
+    MongoNonQueryExpression nonQuery,
+    IProperty keyProperty)
+    => RunInBulkTransaction(queryContext, nonQuery, () =>
+    {
+        var ids = SelectTargetIds<TSource, TKey>(queryContext, entityType, bsonSerializerFactory, nonQuery, keyProperty);
+        return ids.Count == 0 ? 0 : DeleteByIds(queryContext, nonQuery, keyProperty, ids);
+    });
+
+private static Task<int> ExecuteTwoPhaseDeleteAsync<TSource, TKey>(
+    QueryContext queryContext,
+    IReadOnlyEntityType entityType,
+    BsonSerializerFactory bsonSerializerFactory,
+    MongoNonQueryExpression nonQuery,
+    IProperty keyProperty)
+    => RunInBulkTransactionAsync(queryContext, nonQuery, async () =>
+    {
+        var ids = await SelectTargetIdsAsync<TSource, TKey>(
+            queryContext, entityType, bsonSerializerFactory, nonQuery, keyProperty).ConfigureAwait(false);
+        return ids.Count == 0
+            ? 0
+            : await DeleteByIdsAsync(queryContext, nonQuery, keyProperty, ids).ConfigureAwait(false);
+    });
+
+private static int DeleteByIds(
+    QueryContext queryContext, MongoNonQueryExpression nonQuery, IProperty keyProperty, List<BsonValue> ids)
+{
+    var (collection, session) = GetBulkCollectionAndSession(queryContext, nonQuery);
+    var filter = Builders<BsonDocument>.Filter.In(keyProperty.GetElementName(), ids);
+
+    var updateLogger = GetUpdateLogger(queryContext);
+    var stopwatch = Stopwatch.StartNew();
+    updateLogger.ExecutingBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace);
+
+    var result = session == null ? collection.DeleteMany(filter) : collection.DeleteMany(session, filter);
+
+    updateLogger.ExecutedBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace, result.DeletedCount);
+    return checked((int)result.DeletedCount);
+}
+
+private static async Task<int> DeleteByIdsAsync(
+    QueryContext queryContext, MongoNonQueryExpression nonQuery, IProperty keyProperty, List<BsonValue> ids)
+{
+    var (collection, session) = GetBulkCollectionAndSession(queryContext, nonQuery);
+    var filter = Builders<BsonDocument>.Filter.In(keyProperty.GetElementName(), ids);
+
+    var updateLogger = GetUpdateLogger(queryContext);
+    var stopwatch = Stopwatch.StartNew();
+    updateLogger.ExecutingBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace);
+
+    var cancellationToken = queryContext.CancellationToken;
+    var result = session == null
+        ? await collection.DeleteManyAsync(filter, cancellationToken).ConfigureAwait(false)
+        : await collection.DeleteManyAsync(session, filter, options: null, cancellationToken).ConfigureAwait(false);
+
+    updateLogger.ExecutedBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace, result.DeletedCount);
+    return checked((int)result.DeletedCount);
+}
+
+private static (IMongoCollection<BsonDocument> collection, IClientSessionHandle? session) GetBulkCollectionAndSession(
+    QueryContext queryContext, MongoNonQueryExpression nonQuery)
+{
+    var mongoQueryContext = (MongoQueryContext)queryContext;
+    var collection =
+        mongoQueryContext.MongoClient.GetCollection<BsonDocument>(nonQuery.SourceQuery.CollectionExpression.CollectionName);
+    var session = (mongoQueryContext.Context.Database.CurrentTransaction as MongoTransaction)?.Session;
+    return (collection, session);
+}
+```
+
+> `GetBulkCollectionAndSession` factors out the collection+session lookup `PrepareBulk` already does; leave `PrepareBulk` as-is for the single-command path.
+
+Now replace the transitional canonical-error guard in `VisitNonQuery` (from Task 2 Step 5) with real dispatch:
+
+```csharp
+private Expression VisitNonQuery(MongoNonQueryExpression nonQueryExpression)
+{
+    var entityType = nonQueryExpression.SourceQuery.CollectionExpression.EntityType;
+
+    if (nonQueryExpression.Strategy == MongoNonQueryExpression.BulkStrategy.TwoPhase)
+    {
+        var keyProperty = GetBulkKeyOrThrow(entityType, nonQueryExpression);
+        var twoPhaseExecutor = nonQueryExpression.Kind switch
+        {
+            MongoNonQueryExpression.OperationKind.Update =>
+                QueryCompilationContext.IsAsync ? ExecuteTwoPhaseUpdateAsyncMethodInfo : ExecuteTwoPhaseUpdateMethodInfo,
+            _ => QueryCompilationContext.IsAsync ? ExecuteTwoPhaseDeleteAsyncMethodInfo : ExecuteTwoPhaseDeleteMethodInfo
+        };
+
+        return Expression.Call(null,
+            twoPhaseExecutor.MakeGenericMethod(entityType.ClrType, keyProperty.ClrType),
+            QueryCompilationContext.QueryContextParameter,
+            Expression.Constant(entityType),
+            Expression.Constant(_bsonSerializerFactory),
+            Expression.Constant(nonQueryExpression),
+            Expression.Constant(keyProperty));
+    }
+
+    var executor = nonQueryExpression.Kind switch
+    {
+        MongoNonQueryExpression.OperationKind.Update =>
+            QueryCompilationContext.IsAsync ? ExecuteUpdateAsyncMethodInfo : ExecuteUpdateMethodInfo,
+        _ => QueryCompilationContext.IsAsync ? ExecuteDeleteAsyncMethodInfo : ExecuteDeleteMethodInfo
+    };
+
+    return Expression.Call(null,
+        executor.MakeGenericMethod(entityType.ClrType),
+        QueryCompilationContext.QueryContextParameter,
+        Expression.Constant(entityType),
+        Expression.Constant(_bsonSerializerFactory),
+        Expression.Constant(nonQueryExpression));
+}
+```
+
+> `ExecuteTwoPhaseUpdate*MethodInfo` are referenced here but defined in Task 5. To keep this task compiling and green on its own, in **this task** keep the two-phase **update** path on the transitional canonical-error guard (so the update spec tests that assert `"could not be translated"` stay green until Task 5), and dispatch only the **delete** path. Concretely, for this task only, write the `twoPhaseExecutor` selection as delete-only:
+> ```csharp
+> if (nonQueryExpression.Kind == MongoNonQueryExpression.OperationKind.Update)
+> {
+>     // Two-phase update is wired in Task 5; until then preserve the canonical rejection.
+>     throw new InvalidOperationException(
+>         CoreStrings.NonQueryTranslationFailedWithDetails(
+>             nonQueryExpression.SourceQuery.CapturedExpression?.Print(),
+>             "ordering, paging, and 'Distinct' in a bulk delete or update are not yet supported."));
+> }
+> var twoPhaseExecutor = QueryCompilationContext.IsAsync
+>     ? ExecuteTwoPhaseDeleteAsyncMethodInfo : ExecuteTwoPhaseDeleteMethodInfo;
+> ```
+
+- [ ] **Step 5: Add the `MethodInfo` cache entries**
+
+Next to the existing `ExecuteDeleteMethodInfo` etc. (~line 674), add:
+
+```csharp
+private static readonly MethodInfo ExecuteTwoPhaseDeleteMethodInfo =
+    typeof(MongoShapedQueryCompilingExpressionVisitor)
+        .GetTypeInfo().GetDeclaredMethods(nameof(ExecuteTwoPhaseDelete))
+        .Single(m => !m.ReturnType.IsGenericType); // returns int, not Task<int>
+
+private static readonly MethodInfo ExecuteTwoPhaseDeleteAsyncMethodInfo =
+    typeof(MongoShapedQueryCompilingExpressionVisitor)
+        .GetTypeInfo().GetDeclaredMethods(nameof(ExecuteTwoPhaseDeleteAsync))
+        .Single();
+```
+
+> Match the resolution style already used for `ExecuteDeleteMethodInfo` in this file (it uses `.GetTypeInfo().DeclaredMethods` + `.Single(m => m.Name == ...)`). Mirror that exact pattern rather than the sketch above if it differs.
+
+- [ ] **Step 6: Run the acceptance tests**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~ExecuteDeleteTests"`
+Expected: PASS — all the two-phase delete tests plus the unchanged single-command tests.
+
+- [ ] **Step 7: Run on EF9 too**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF9" --filter "FullyQualifiedName~ExecuteDeleteTests"`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs \
+        tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs
+git commit -m "EF-107: Two-phase ExecuteDelete for ordered/paged/distinct sources"
+```
+
+---
+
+## Task 5: Wire two-phase `ExecuteUpdate`
+
+Phase 1 + transaction scope are shared from Tasks 3–4. This task adds the update phase-2 (reuse `BuildUpdate`) and removes the transitional update guard from Task 4.
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs`
+- Test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateTests.cs`
+
+- [ ] **Step 1: Write the failing acceptance tests**
+
+Mirror the `ExecuteUpdateTests` model/seed conventions (check the top of that file for its entity + `CreateSeededContext`). Add:
+
+```csharp
+[Fact]
+public void ExecuteUpdate_with_OrderBy_Take_updates_only_targeted_rows()
+{
+    using var db = CreateSeededContext();
+
+    var updated = db.Entities
+        .OrderBy(o => o.Quantity).Take(2)
+        .ExecuteUpdate(s => s.SetProperty(o => o.Status, "archived"));
+
+    Assert.Equal(2, updated); // matched count
+    Assert.Equal(2, db.Entities.Count(o => o.Status == "archived"));
+}
+
+[Fact]
+public void ExecuteUpdate_two_phase_self_referencing_setter()
+{
+    using var db = CreateSeededContext();
+
+    var updated = db.Entities
+        .OrderBy(o => o.Quantity).Take(1)
+        .ExecuteUpdate(s => s.SetProperty(o => o.Quantity, o => o.Quantity + 5));
+
+    Assert.Equal(1, updated);
+    Assert.Contains(db.Entities.ToList(), o => o.Quantity == 15); // lowest was 10
+}
+
+[Fact]
+public void ExecuteUpdate_two_phase_rolls_back_inside_user_transaction()
+{
+    using var db = CreateSeededContext();
+    using (var tx = db.Database.BeginTransaction())
+    {
+        db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteUpdate(s => s.SetProperty(o => o.Status, "archived"));
+        tx.Rollback();
+    }
+
+    Assert.Equal(0, db.Entities.Count(o => o.Status == "archived"));
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~ExecuteUpdateTests.ExecuteUpdate_with_OrderBy_Take_updates_only_targeted_rows"`
+Expected: FAIL — the transitional guard still rejects two-phase update with the canonical "could not be translated" error, so no update happens and the assertions fail.
+
+- [ ] **Step 3: Add the two-phase update executors**
+
+```csharp
+private static int ExecuteTwoPhaseUpdate<TSource, TKey>(
+    QueryContext queryContext,
+    IReadOnlyEntityType entityType,
+    BsonSerializerFactory bsonSerializerFactory,
+    MongoNonQueryExpression nonQuery,
+    IProperty keyProperty)
+    => RunInBulkTransaction(queryContext, nonQuery, () =>
+    {
+        var ids = SelectTargetIds<TSource, TKey>(queryContext, entityType, bsonSerializerFactory, nonQuery, keyProperty);
+        if (ids.Count == 0)
+        {
+            return 0;
+        }
+
+        var update = TranslateBulkOrThrow(nonQuery,
+            () => BuildUpdate<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery));
+        return UpdateByIds(queryContext, nonQuery, keyProperty, ids, update);
+    });
+
+private static Task<int> ExecuteTwoPhaseUpdateAsync<TSource, TKey>(
+    QueryContext queryContext,
+    IReadOnlyEntityType entityType,
+    BsonSerializerFactory bsonSerializerFactory,
+    MongoNonQueryExpression nonQuery,
+    IProperty keyProperty)
+    => RunInBulkTransactionAsync(queryContext, nonQuery, async () =>
+    {
+        var ids = await SelectTargetIdsAsync<TSource, TKey>(
+            queryContext, entityType, bsonSerializerFactory, nonQuery, keyProperty).ConfigureAwait(false);
+        if (ids.Count == 0)
+        {
+            return 0;
+        }
+
+        var update = TranslateBulkOrThrow(nonQuery,
+            () => BuildUpdate<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery));
+        return await UpdateByIdsAsync(queryContext, nonQuery, keyProperty, ids, update).ConfigureAwait(false);
+    });
+
+private static int UpdateByIds(
+    QueryContext queryContext, MongoNonQueryExpression nonQuery, IProperty keyProperty,
+    List<BsonValue> ids, UpdateDefinition<BsonDocument> update)
+{
+    var (collection, session) = GetBulkCollectionAndSession(queryContext, nonQuery);
+    var filter = Builders<BsonDocument>.Filter.In(keyProperty.GetElementName(), ids);
+
+    var updateLogger = GetUpdateLogger(queryContext);
+    var stopwatch = Stopwatch.StartNew();
+    updateLogger.ExecutingBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace);
+
+    var result = session == null
+        ? collection.UpdateMany(filter, update)
+        : collection.UpdateMany(session, filter, update);
+
+    updateLogger.ExecutedBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace, result.ModifiedCount);
+    return checked((int)result.MatchedCount);
+}
+
+private static async Task<int> UpdateByIdsAsync(
+    QueryContext queryContext, MongoNonQueryExpression nonQuery, IProperty keyProperty,
+    List<BsonValue> ids, UpdateDefinition<BsonDocument> update)
+{
+    var (collection, session) = GetBulkCollectionAndSession(queryContext, nonQuery);
+    var filter = Builders<BsonDocument>.Filter.In(keyProperty.GetElementName(), ids);
+
+    var updateLogger = GetUpdateLogger(queryContext);
+    var stopwatch = Stopwatch.StartNew();
+    updateLogger.ExecutingBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace);
+
+    var cancellationToken = queryContext.CancellationToken;
+    var result = session == null
+        ? await collection.UpdateManyAsync(filter, update, options: null, cancellationToken).ConfigureAwait(false)
+        : await collection.UpdateManyAsync(session, filter, update, options: null, cancellationToken).ConfigureAwait(false);
+
+    updateLogger.ExecutedBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace, result.ModifiedCount);
+    return checked((int)result.MatchedCount);
+}
+```
+
+- [ ] **Step 4: Add the `MethodInfo` cache entries and restore the update dispatch**
+
+Add (matching the file's existing resolution pattern):
+
+```csharp
+private static readonly MethodInfo ExecuteTwoPhaseUpdateMethodInfo =
+    typeof(MongoShapedQueryCompilingExpressionVisitor)
+        .GetTypeInfo().GetDeclaredMethods(nameof(ExecuteTwoPhaseUpdate))
+        .Single(m => !m.ReturnType.IsGenericType);
+
+private static readonly MethodInfo ExecuteTwoPhaseUpdateAsyncMethodInfo =
+    typeof(MongoShapedQueryCompilingExpressionVisitor)
+        .GetTypeInfo().GetDeclaredMethods(nameof(ExecuteTwoPhaseUpdateAsync))
+        .Single();
+```
+
+In `VisitNonQuery`, remove the Task-4 transitional update guard (the `if (nonQueryExpression.Kind == …Update) throw …NonQueryTranslationFailedWithDetails(…)` block) and restore the full `twoPhaseExecutor` switch shown in Task 4 Step 4 (the version that handles both `Update` and delete).
+
+- [ ] **Step 5: Run the acceptance tests**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~ExecuteUpdateTests"`
+Expected: PASS — two-phase update tests + unchanged single-command update tests (including the EF9 empty-setter guard).
+
+- [ ] **Step 6: Run on EF9**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF9" --filter "FullyQualifiedName~ExecuteUpdateTests"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs \
+        tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateTests.cs
+git commit -m "EF-107: Two-phase ExecuteUpdate for ordered/paged/distinct sources"
+```
+
+---
+
+## Task 6: Diagnostics — surface two-phase + target count
+
+The existing `ExecutingBulkDelete`/`…Update` log messages don't distinguish single-command from two-phase. Add a target-count detail without minting new event IDs.
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerUpdateExtensions.cs`
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs` (pass the count)
+- Test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs`
+
+- [ ] **Step 1: Inspect the current logger signatures**
+
+Run: `grep -n "ExecutingBulkDelete\|ExecutingBulkUpdate\|ExecutedBulkDelete\|ExecutedBulkUpdate" src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerUpdateExtensions.cs`
+Read those methods to learn their exact parameters and the message templates. Decide the smallest change: add an optional `int? targetCount = null` parameter to the `Executing*` overloads (or a sibling overload) that, when set, appends "(two-phase, N targets)" to the logged message.
+
+- [ ] **Step 2: Write the failing test**
+
+Use the existing diagnostics-capture pattern from the bulk-event tests already in `ExecuteDeleteTests` (the Task-2 file `using`s `MongoDB.EntityFrameworkCore.Diagnostics`; find the existing test that asserts `ExecutingBulkDelete` fired and copy its capture mechanism — likely a `ListLoggerFactory`/`TestMqlLoggerFactory` or an `ILoggerProvider`). Assert that a two-phase delete logs the target count:
+
+```csharp
+[Fact]
+public void ExecuteDelete_two_phase_logs_target_count()
+{
+    // Arrange capture exactly as the existing bulk-event test in this file does.
+    using var db = CreateSeededContextWithLogCapture(out var logEntries);
+
+    db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDelete();
+
+    Assert.Contains(logEntries, e => e.Contains("two-phase") && e.Contains("2"));
+}
+```
+
+> If no log-capture helper exists in this file yet, reuse the project's standard one referenced in `tests/MongoDB.EntityFrameworkCore.SpecificationTests/Utilities/TestMqlLoggerFactory.cs` or the functional `ListLoggerFactory`. Do not invent a new logging harness.
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~ExecuteDeleteTests.ExecuteDelete_two_phase_logs_target_count"`
+Expected: FAIL — the message has no "two-phase" / count detail.
+
+- [ ] **Step 4: Add the count to the log call**
+
+In `MongoLoggerUpdateExtensions.cs`, extend the `ExecutingBulkDelete`/`ExecutingBulkUpdate` message to optionally include the target count (follow the file's existing `LoggerMessage`/definition style — if the messages are built via `MongoLoggingDefinitions`, thread the parameter through there too). In `DeleteByIds`/`DeleteByIdsAsync`/`UpdateByIds`/`UpdateByIdsAsync` (Tasks 4–5), pass `ids.Count` into the `Executing*` call.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~ExecuteDeleteTests.ExecuteDelete_two_phase_logs_target_count"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerUpdateExtensions.cs \
+        src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs \
+        tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs
+git commit -m "EF-107: Log two-phase bulk target count on existing bulk events"
+```
+
+---
+
+## Task 7: Transaction-policy tests (`Never`, standalone)
+
+**Files:**
+- Test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs`
+
+- [ ] **Step 1: Write the `Never` test**
+
+```csharp
+[Fact]
+public void ExecuteDelete_two_phase_with_AutoTransactionBehavior_Never_throws_and_changes_nothing()
+{
+    using var db = CreateSeededContext();
+    db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+
+    var ex = Assert.Throws<InvalidOperationException>(
+        () => db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDelete());
+
+    Assert.Contains("AutoTransactionBehavior", ex.Message);
+    Assert.Equal(3, db.Entities.Count()); // nothing deleted
+}
+
+[Fact]
+public void ExecuteDelete_single_command_with_AutoTransactionBehavior_Never_still_works()
+{
+    using var db = CreateSeededContext();
+    db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+
+    // Where-only path is single-command and needs no transaction — Never must not affect it.
+    var deleted = db.Entities.Where(o => o.Status == "open").ExecuteDelete();
+
+    Assert.Equal(2, deleted);
+}
+```
+
+Add `using Microsoft.EntityFrameworkCore;` to the test file if needed (for `AutoTransactionBehavior`).
+
+- [ ] **Step 2: Add the standalone test (environment-guarded)**
+
+The local/CI test server supports transactions, so a real standalone can't be exercised here. Document the path with a clearly-reasoned skip rather than a silent omission:
+
+```csharp
+[Fact(Skip = "Requires a standalone (non-replica-set) MongoDB to exercise the transaction-unsupported path; "
+    + "CI/local use a replica set (atlas-local). The error mapping is covered by IsTransactionsUnsupported. EF-107")]
+public void ExecuteDelete_two_phase_on_standalone_throws_actionable_error()
+{
+    // Intentionally skipped — see Skip reason.
+}
+```
+
+- [ ] **Step 3: Run the policy tests**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~ExecuteDeleteTests.ExecuteDelete_two_phase_with_AutoTransactionBehavior_Never_throws_and_changes_nothing|FullyQualifiedName~ExecuteDeleteTests.ExecuteDelete_single_command_with_AutoTransactionBehavior_Never_still_works"`
+Expected: PASS (standalone test reported as skipped).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs
+git commit -m "EF-107: Transaction-policy tests for two-phase bulk (Never, standalone)"
+```
+
+---
+
+## Task 8: Spec-suite — promote now-supported `NorthwindBulkUpdates` cases to green
+
+**Files:**
+- Modify: `tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindBulkUpdatesMongoTest.cs`
+- Modify: `docs/failing-spec-tests.md`
+
+- [ ] **Step 1: Identify the ordering/paging/distinct cases tagged EF-X016**
+
+Run: `grep -n "ordering / paging / Distinct unsupported EF-X016" tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindBulkUpdatesMongoTest.cs`
+These are the `Delete_Where_OrderBy*`, `Delete_Where_Skip*`, `Delete_Where_Take`, `Delete_Where_Distinct`, and the equivalent `Update_*` cases currently routed through `AssertTranslationFailed`.
+
+- [ ] **Step 2: Convert each to call `base` (one at a time, verifying)**
+
+For each such method, replace the `AssertTranslationFailed(() => base.X(async))` body with the upstream-driven `await base.X(async)` and the appropriate `AssertMql`/assertion the sibling supported tests use. Remove its `// Fails: … EF-X016` comment.
+
+Important caveats to verify per-test as you go:
+- The `NorthwindBulkUpdates` asserter runs inside its rollback transaction (the fixture enlists the second context). Two-phase ops join that ambient transaction (the ambient-transaction path) — confirm they execute and the asserter's post-state checks pass.
+- `Delete_Where_Skip_Take_Skip_Take_causing_subquery` may still not translate (a nested-subquery shape the read path can't express). If `base` throws, **leave it** as `AssertTranslationFailed` with an updated `// Fails:` reason ("nested Skip/Take subquery unsupported EF-X016") rather than forcing it green.
+
+Run each converted test immediately:
+`dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --no-build --filter "FullyQualifiedName~NorthwindBulkUpdatesMongoTest.Delete_Where_OrderBy_Take"`
+Expected: PASS. Repeat for each.
+
+- [ ] **Step 3: Run the full bulk-updates spec class on EF9 and EF10**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --no-build --filter "FullyQualifiedName~NorthwindBulkUpdatesMongoTest"`
+Then EF9. Expected: 0 failed; skipped only where explicitly documented.
+
+- [ ] **Step 4: Update `docs/failing-spec-tests.md`**
+
+In the `EF-X016` section, remove the ordering/paging/Distinct shapes from the unsupported list (they're now supported via two-phase) and keep only the still-unsupported shapes (Join/GroupBy/SelectMany/set-ops, multiple-collection, and any nested-subquery case left failing in Step 2). Note the two-phase support and its transaction requirement.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindBulkUpdatesMongoTest.cs \
+        docs/failing-spec-tests.md
+git commit -m "EF-107: Promote ordered/paged/distinct bulk spec cases to green"
+```
+
+---
+
+## Task 9: README, design-doc reconciliation, and full multi-EF run
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-06-11-bulk-two-phase-execute-update-delete-design.md`
+
+- [ ] **Step 1: Update the design doc to match the implemented transaction rule**
+
+In the design doc, change the "Empty phase 1" decision row and §6 to state that **phase 1 runs inside the transaction** (ambient or auto-started); an empty result commits a no-op transaction and returns 0 — the "skip the transaction entirely" wording is removed because a non-empty phase 1 run outside a transaction would reopen the race.
+
+- [ ] **Step 2: Update README**
+
+Run: `grep -n "ExecuteDelete\|ExecuteUpdate\|bulk" README.md`
+Update the bulk-operations description to note that `Where`-scoped ops are a single atomic command, and ordering/paging/`Distinct`-scoped ops are supported via a transactional two-phase execution (requiring a transaction-capable deployment).
+
+- [ ] **Step 3: Full build + test across all EF versions**
+
+Invoke the `/test-all` skill (builds + tests EF8, EF9, EF10 in parallel).
+Expected: EF8 still rejects bulk entirely; EF9/EF10 green including the new two-phase tests and the promoted spec cases.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/superpowers/specs/2026-06-11-bulk-two-phase-execute-update-delete-design.md
+git commit -m "EF-107: Document two-phase bulk support; reconcile design doc"
+```
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** §2 classifier → Task 2; §3 marker → Task 1; §4 phase 1 → Task 3; §5 phase 2 + transaction lifecycle → Tasks 4–5, 7; §6 counts/edge cases → Tasks 4–5; §7 diagnostics → Task 6; §8 multi-EF/guards → all tasks under `#if !EF8`, verified in Task 9; §9 testing → Tasks 4–8.
+- **Key uncertainty to resolve early (Task 3 Step 4):** the exact async-materialization API for the driver-LINQ key query (`MongoQueryable.ToListAsync` vs `IAsyncCursorSourceExtensions.ToListAsync`). Confirm by compiling; don't proceed to Task 4 until phase 1 builds on all three EF versions.
+- **Method-name consistency:** `SelectTargetIds`/`SelectTargetIdsAsync`, `BuildKeyQuery`, `GetBulkKeyOrThrow`, `GetBulkCollectionAndSession`, `RunInBulkTransaction`/`Async`, `DeleteByIds`/`Async`, `UpdateByIds`/`Async`, `ExecuteTwoPhaseDelete`/`Async`, `ExecuteTwoPhaseUpdate`/`Async`, `IsTransactionsUnsupported`, `NoAutoTransactionError`, `StandaloneTransactionError` — used identically across Tasks 3–6.
+- **Don't touch the single-command path:** `PrepareBulk`, `BuildFilter`, `ExecuteDelete`/`ExecuteUpdate` (and async) stay exactly as they are; two-phase is additive.

--- a/docs/superpowers/specs/2026-06-09-execute-update-delete-design.md
+++ b/docs/superpowers/specs/2026-06-09-execute-update-delete-design.md
@@ -1,0 +1,189 @@
+# ExecuteUpdate / ExecuteDelete for the MongoDB EF Core Provider — Design
+
+**Date:** 2026-06-09
+**Status:** Approved (design); pending implementation plan
+**JIRA:** TBD (`EF-NNN`)
+
+## Summary
+
+Implement EF Core's bulk-operation APIs — `ExecuteDelete()` / `ExecuteDeleteAsync()` and
+`ExecuteUpdate(...)` / `ExecuteUpdateAsync(...)` — in the MongoDB EF Core provider. These
+execute a single server-side `deleteMany` / `updateMany` against one collection, bypassing
+the change tracker, instead of loading entities and saving them back. This is the highest-ROI
+independent feature gap identified in the provider's gap analysis: MongoDB has native
+multi-document update/delete, so the impedance is low and the performance upside (no
+load-into-change-tracker round trip) is high.
+
+## Background
+
+`ExecuteDelete`/`ExecuteUpdate` were **relational-only in EF8** and were promoted into EF Core
+*core* in EF9. The EF8 public extension methods live in `EFCore.Relational`
+(`RelationalQueryableExtensions`), which this provider deliberately does not reference, and the
+core base class `QueryableMethodTranslatingExpressionVisitor` has **no** `TranslateExecuteDelete`/
+`TranslateExecuteUpdate` virtuals in EF8. Therefore the feature is supportable only on **EF9 and
+EF10** and must be gated behind `#if !EF8`.
+
+The relational reference behavior (confirmed against the EF Core source):
+
+- `NonQueryResult` / `NonQueryResultAsync` in `RelationalShapedQueryCompilingExpressionVisitor`
+  issues exactly **one** SQL statement — no `BeginTransaction`, no `IDbContextTransaction`.
+  Atomicity of a standalone bulk op comes from the single statement being inherently atomic at
+  the database level.
+- The command **enlists in the context's `CurrentTransaction`** if one is already open.
+- The `IExecutionStrategy.Execute` wrapper around it is about **retry on transient failures**,
+  not atomicity.
+
+We mirror this contract for MongoDB.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| EF version support | EF9 + EF10 only (`#if !EF8`). EF8 cannot reach the core hooks. |
+| ExecuteUpdate value scope | Constants/parameters via `$set`; self-referencing expressions (e.g. `e => e.Count + 1`) via aggregation pipeline-form updates. |
+| Transaction semantics | Match relational: thread `CurrentTransaction.Session` if open; otherwise a single un-wrapped `updateMany`/`deleteMany`. No implicit transaction of our own. |
+| Concurrency | Bypasses the change tracker; optimistic-concurrency tokens are **not** checked (standard EF behavior for these APIs). |
+| Public API | None added — the EF9/EF10 extension methods already exist in `EntityFrameworkQueryableExtensions`. |
+
+## Scope & boundaries
+
+**In scope**
+
+- `ExecuteDelete()` / `ExecuteDeleteAsync(CancellationToken)`.
+- `ExecuteUpdate(...)` / `ExecuteUpdateAsync(...)` on a single `DbSet`.
+- Source query scoped by `Where(...)` predicate(s) that the existing EF→driver-LINQ translator
+  can render.
+- TPH inheritance: the discriminator filter the query pipeline already injects **must** be
+  preserved in the bulk filter, so a bulk op on a derived type only affects documents of that
+  type.
+
+**Out of scope (v1) — must throw the canonical EF "could not be translated" message**
+
+- Any source-chain operator beyond filtering: `OrderBy`/`ThenBy`, `Skip`/`Take`, `Select`/
+  projection, `Distinct`, set operations, joins, cross-collection / cross-`DbSet` predicates.
+  `deleteMany`/`updateMany` take only a filter, so ordering/paging have no server-side meaning.
+- Owned / nested-navigation setters. v1 setters target **root scalar properties only**.
+
+**Return value**
+
+- `int` affected-count, cast from the driver's `long` `ModifiedCount` (update) /
+  `DeletedCount` (delete), matching EF's `int`-returning API surface.
+
+## Architecture
+
+### Dispatch path (EF9/EF10)
+
+```
+query.ExecuteDelete()/.ExecuteUpdate(...)            (EntityFrameworkQueryableExtensions)
+   │  Provider.Execute<int>(Expression.Call(ExecuteDeleteMethodInfo/..., source))
+   ▼
+QueryCompiler.Execute<int> → IDatabase.CompileQuery<int>
+   ▼
+MongoQueryableMethodTranslatingExpressionVisitor
+   │  VisitMethodCall lets the EntityFrameworkQueryableExtensions markers through to base
+   │  dispatch (the AllowedQueryableExtensions gate must NOT short-circuit them)
+   │  base dispatch → TranslateExecuteDelete(source) / TranslateExecuteUpdate(source, setters)
+   │  → returns a MongoNonQueryExpression
+   ▼
+MongoShapedQueryCompilingExpressionVisitor.VisitExtension
+   │  recognizes MongoNonQueryExpression
+   │  → emits Expression.Call(NonQueryResult / NonQueryResultAsync, queryContext, ...)
+   ▼
+static NonQueryResult(queryContext, ...) : int        (NonQueryResultAsync : Task<int>)
+       ├─ resolve IMongoCollection by collection name
+       ├─ build FilterDefinition from captured predicate (+ discriminator)
+       ├─ build UpdateDefinition (update only)
+       ├─ thread CurrentTransaction.Session if present
+       └─ collection.UpdateMany / DeleteMany → return (int) count
+```
+
+### New components
+
+- **`Query/Expressions/MongoNonQueryExpression.cs`** — marker node analogous to relational's
+  `NonQueryExpression`. Carries:
+  - the source `MongoQueryExpression` (collection name + captured predicate chain),
+  - a kind enum (`Delete` / `Update`),
+  - for update: an ordered list of setters `(IProperty target, Expression valueExpr,
+    bool isSelfReferencing)`.
+
+- **SetProperty-chain extraction** (version-split):
+  - **EF9** — `TranslateExecuteUpdate(ShapedQueryExpression source, LambdaExpression
+    setPropertyCalls)`. We walk the chained `.SetProperty(...)` calls ourselves.
+  - **EF10** — `TranslateExecuteUpdate(ShapedQueryExpression source,
+    IReadOnlyList<ExecuteUpdateSetter> setters)`. EF hands us parsed
+    `(PropertySelector, ValueExpression)` pairs (a `Convert`-to-`object` wrapper on
+    value-type values is stripped by EF).
+  - Guarded with `#if EF10 / #elif EF9`.
+
+- **Update-definition builder:**
+  - Constant / parameter setters → `Builders<BsonDocument>.Update.Set(elementName,
+    serializedValue)`, value serialized through `BsonSerializerFactory` (same path the write
+    pipeline uses in `MongoUpdate`).
+  - Self-referencing setters → aggregation **pipeline-form** update
+    `[{ $set: { <element>: <renderedExpr> } }]`.
+
+- **Bulk executor** — static `NonQueryResult` / `NonQueryResultAsync` (mirroring relational's
+  shape): resolve `IMongoCollection<…>` by collection name, build the filter, call
+  `UpdateMany`/`DeleteMany` (threading `CurrentTransaction.Session` if present), return the
+  count. Wrapped in the execution strategy for retry parity with relational.
+
+### Modified components
+
+- **`Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs`**
+  - `#if !EF8` overrides of `TranslateExecuteDelete` / `TranslateExecuteUpdate` that return a
+    `MongoNonQueryExpression`.
+  - The `AllowedQueryableExtensions` gate (currently `:82`) must allow the
+    `EntityFrameworkQueryableExtensions` `ExecuteDelete`/`ExecuteUpdate` marker methods to reach
+    base dispatch instead of returning `NotTranslatedExpression`.
+
+- **`Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs`**
+  - Add a `VisitExtension` override recognizing `MongoNonQueryExpression` and emitting the
+    `Expression.Call` to the static executor. (Today it overrides only `VisitShapedQuery`.)
+
+## Filter & value translation (reuse)
+
+- **Filter.** Reuse the EF→driver-LINQ predicate translation — the same mechanism the
+  vector-search pre-filter uses to produce an `ExpressionFilterDefinition` from a translated
+  lambda over the entity type (see `MongoEFToLinqTranslatingExpressionVisitor`, the VectorSearch
+  pre-filter path). Turn the captured `Where` chain (plus any discriminator filter) into a
+  `FilterDefinition`. The supported source query reduces to a filter-only chain; anything else
+  throws.
+
+- **Self-referencing values — primary technical risk.** Rendering `e => e.Count + 1` to the
+  aggregation expression `{$add: ["$count", 1]}`. The implementation plan will **spike** the
+  exact rendering path (reusing `MongoEFToLinqTranslatingExpressionVisitor`'s expression
+  translation vs. driver aggregation-expression rendering) before committing. If the spike shows
+  the cost is disproportionate, the fallback is to ship constants-only in v1 and pipeline-form
+  self-referencing updates as a fast-follow — flagged explicitly at the spike, not decided
+  silently.
+
+## Testing
+
+- **Unit tests** (`tests/MongoDB.EntityFrameworkCore.UnitTests/`) — translator tests asserting
+  the produced filter + update BSON for: delete, constant-`$set`, and self-referencing-`$set`
+  cases; and that unsupported source shapes (`OrderBy`/`Take`/`Select`/projection) throw the
+  canonical EF translation-failure message. Run across EF9 and EF10.
+
+- **Functional tests** (`tests/MongoDB.EntityFrameworkCore.FunctionalTests/`, real DB) —
+  end-to-end delete and update with MQL assertions; transaction-enlistment behavior (op runs in
+  an open `MongoTransaction`'s session); and the no-implicit-transaction path on a standalone
+  server.
+
+- **Specification conformance**
+  (`tests/MongoDB.EntityFrameworkCore.SpecificationTests/`) — wire up EF Core's `BulkUpdates`
+  specification test base (Northwind) with MongoDB overrides, following the existing
+  override-and-assert pattern; annotate any still-unsupported shapes with `// Fails:` ticket tags
+  per `docs/failing-spec-tests.md` conventions.
+
+- **EF8 boundary** — a test asserting the methods are unavailable / surface a clear
+  "not supported on EF8" path, so the version boundary is explicit and intentional.
+
+## Risks & open questions
+
+1. **Self-referencing value rendering** (see above) — the one real unknown; resolved by a spike
+   in the implementation plan with a documented fallback.
+2. **Filter typing** — exact collection/serializer typing for the `FilterDefinition`
+   (`IMongoCollection<BsonDocument>` vs entity-typed) is an implementation detail to settle in
+   the plan; the vector-search pre-filter proves the `ExpressionFilterDefinition` pattern works.
+3. **`int` overflow** — counts exceeding `int.MaxValue` are truncated to match EF's `int` API.
+   Same behavior as relational; documented, not guarded.

--- a/docs/superpowers/specs/2026-06-11-bulk-two-phase-execute-update-delete-design.md
+++ b/docs/superpowers/specs/2026-06-11-bulk-two-phase-execute-update-delete-design.md
@@ -1,0 +1,214 @@
+# Two-phase `ExecuteUpdate` / `ExecuteDelete` for ordered / paged / distinct sources — Design
+
+**Date:** 2026-06-11
+**Status:** Approved (design); pending implementation plan
+**JIRA:** EF-107 (follow-on to the initial bulk implementation)
+
+## Summary
+
+Extend the provider's server-side bulk `ExecuteDelete` / `ExecuteUpdate` so the source query may
+combine `Where` with `OrderBy` / `ThenBy` / `Skip` / `Take` / `Distinct`. MongoDB's
+`deleteMany` / `updateMany` take only a filter predicate — no `sort`, no `limit` — so these shapes
+cannot be expressed as a single command and are rejected today. We add a **two-phase `_id`
+emulation**: phase 1 runs the source query as an ordinary read projecting only the primary key
+(`_id`); phase 2 issues `deleteMany` / `updateMany` filtered by `{ _id: { $in: <ids> } }`. This is
+implemented entirely in the provider — no server or driver change required.
+
+The existing `Where`-only path is **unchanged**: it remains a single atomic `deleteMany` /
+`updateMany` with no transaction. The two-phase path is used only for the shapes that would
+otherwise fail, and it wraps the two operations in a transaction for race-safety — so the
+transaction cost is incurred only where the alternative is a hard failure.
+
+## Background
+
+The initial EF-107 work (`2026-06-09-execute-update-delete-design.md`) compiles a bulk operation
+into one server command and rejects any source operator other than `Queryable.Where`
+(`ValidateBulkSource` in `MongoQueryableMethodTranslatingExpressionVisitor`). The follow-on
+analysis (`docs/failing-spec-tests.md`, `EF-X016`) identified a **provider-only alternative** for
+the sort / limit / distinct family: query the target `_id`s, then act on them by `$in`. Its
+trade-off is the loss of single-statement atomicity, recovered by running both phases inside a
+transaction.
+
+Key architectural fact that makes this clean (verified in
+`MongoQueryableMethodTranslatingExpressionVisitor` and
+`MongoShapedQueryCompilingExpressionVisitor`):
+
+- The provider does **not** translate `OrderBy` / `Skip` / `Take` / `Distinct` into pipeline stages
+  itself. `VisitMethodCall` captures the whole LINQ chain as `MongoQueryExpression.CapturedExpression`
+  and hands it to the **driver's LINQ v3 provider**, which generates the pipeline. These operators
+  are *not* in the switch that routes to the `null`-returning `Translate*` overrides, so they pass
+  through and the read path already supports them.
+- `Join` / `GroupBy` / `SelectMany` / `Intersect` / `Except` are deliberately routed to `base`
+  precisely so they hit the `null` overrides and throw a clean "not supported" error. The read path
+  **cannot** translate them.
+
+So the set of shapes the two-phase path can support is exactly "what the read path can already
+project." That boundary is self-enforcing: an operator the read path can't translate cannot reach
+phase 1.
+
+`TranslateQuery<TSource>` (in `MongoShapedQueryCompilingExpressionVisitor`) is the existing reusable
+hook — it builds the driver `IQueryable<TSource>` from `collection.AsQueryable(session)`, wraps it
+in the EF entity serializer, and translates the captured chain through
+`MongoEFToLinqTranslatingExpressionVisitor`. Phase 1 reuses it with a key projection, so all
+operator translation stays in one place (the driver).
+
+### Out of scope
+
+Read-side translation of `Join` / `GroupBy` / `SelectMany` / set operations is a separate, larger
+query-engine feature (valuable well beyond bulk, with its own feasibility risk against the driver's
+LINQ v3 capabilities). Once it exists, bulk inherits it for free through the same two-phase
+machinery. It is **not** part of this work. Multiple-collection updates remain rejected — a
+relational table-sharing concept with no document-model meaning.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| EF version support | EF9 + EF10 only, under the existing `#if !EF8` gate. EF8 still rejects bulk entirely. |
+| Shapes added | `Where` combined with `OrderBy` / `OrderByDescending` / `ThenBy` / `ThenByDescending` / `Skip` / `Take` / `Distinct`. |
+| Shapes still rejected | `Join` / `GroupBy` / `SelectMany` / `Intersect` / `Except` / `Select` / any other operator → canonical non-query translation error (unchanged). |
+| `Where`-only path | Unchanged — single atomic `deleteMany` / `updateMany`, no transaction. |
+| Phase-1 execution | Reuse `TranslateQuery<TSource>` with a primary-key (`_id`) projection; the driver translates `OrderBy`/`Skip`/`Take`/`Distinct`. |
+| Phase-2 execution | `deleteMany` / `updateMany` filtered by `{ _id: { $in: <ids> } }`; update reuses existing `BuildUpdate` (`$set` / pipeline). |
+| Transaction (ambient present) | Both phases run on the ambient `CurrentTransaction.Session`; provider does **not** commit (user owns it). |
+| Transaction (none present) | Auto-begin on a fresh session, commit on success, abort on exception. |
+| `AutoTransactionBehavior.Never` | Throw an actionable error telling the user to open a transaction for this shape, instead of auto-starting. |
+| No transaction support (standalone) | Throw an actionable error naming the requirement. |
+| Phase 1 placement | Runs **inside** the transaction scope (ambient or auto-started), so phase 1 and phase 2 share one snapshot. |
+| Empty phase 1 | Skip phase 2; the auto-started transaction commits as a no-op (nothing written); return 0. |
+| Return value | Phase-2 `DeletedCount` / `MatchedCount`, same `checked((int))` overflow contract as the single-command path. |
+| Concurrency tokens | Not checked (standard EF behavior for these APIs; unchanged). |
+| Diagnostics | Reuse existing `Executing/ExecutedBulkDelete` / `…Update` event IDs; add a two-phase / target-count detail. No new event IDs. |
+| Public surface | None. `MongoNonQueryExpression` stays `internal`. |
+
+## Components & data flow
+
+```
+ExecuteDelete / ExecuteUpdate  (EF core hook, EF9/EF10)
+   │
+   ▼  MongoQueryableMethodTranslatingExpressionVisitor
+   │      TranslateExecuteDelete / TranslateExecuteUpdate
+   │      └─ ClassifyBulkSource(chain):
+   │            Where-only            → Strategy.SingleCommand
+   │            + OrderBy/Skip/Take/Distinct → Strategy.TwoPhase
+   │            anything else         → canonical non-query error
+   │      → MongoNonQueryExpression { Kind, Setters, Strategy, SourceQuery }
+   │
+   ▼  MongoShapedQueryCompilingExpressionVisitor   (Execute/ExecuteAsync<TSource>)
+          SingleCommand → existing path: BuildFilter → deleteMany/updateMany (no txn)
+          TwoPhase:
+            ├─ acquire session (see Transaction lifecycle)
+            ├─ phase 1: TranslateQuery<TSource>(source chain + Select(_id)) → enumerate ids
+            ├─ if ids empty → return 0 (no txn, no phase 2)
+            ├─ phase 2: deleteMany/updateMany({ _id: { $in: ids } }) on session
+            └─ commit (if auto-started) / abort on exception
+```
+
+### Translate-time: `ClassifyBulkSource`
+
+`ValidateBulkSource` becomes `ClassifyBulkSource`, returning the strategy. It walks the captured
+chain (after `UnwrapBulkOperator`) and:
+
+- accepts `Queryable.Where` (as today) — contributes to the predicate;
+- accepts `Queryable.OrderBy` / `OrderByDescending` / `ThenBy` / `ThenByDescending` / `Skip` /
+  `Take` / `Distinct` — marks the operation `TwoPhase`;
+- rejects anything else with the canonical `NonQueryTranslationFailedWithDetails` error and the same
+  "Only … can scope a bulk operation" detail message, extended to name the now-supported operators.
+
+Matching is by canonical `MethodInfo` on `typeof(Queryable)` (consistent with the existing
+reference-equality discipline), so a same-named operator from another type still rejects.
+
+### Marker node: `MongoNonQueryExpression`
+
+Add `enum Strategy { SingleCommand, TwoPhase }` and a `Strategy Strategy { get; }` property set in
+both constructors (Delete and Update). No other change — `SourceQuery.CapturedExpression` already
+carries the full chain phase 1 needs.
+
+### Execute-time: phase 1 (key projection)
+
+For `TwoPhase`, reuse `TranslateQuery<TSource>` against `SourceQuery`, with the translate callback
+appending a projection to the entity's primary-key property, and enumerate (sync/async per
+`IsAsync`) on the acquired session to collect the `_id` values.
+
+- MongoDB maps every entity's primary key to a single `_id` field — scalar for a single-property
+  key, or a composite sub-document for composite keys. Both shapes are supported: `$in` works
+  uniformly with either value type, so no special-casing is needed.
+- The **implemented** phase 1 reads whole documents via the normal read path and retains only the
+  `_id` field on the client side; it does **not** issue a server-side `{ _id: 1 }` projection.
+  Adding a server-side `{ _id: 1 }` projection to reduce wire transfer is a possible future
+  optimization but is out of scope for the current implementation.
+- If a key projection cannot be formed (owned/keyless edge cases that cannot be a bulk root), fall
+  back to the canonical non-query error.
+
+### Execute-time: phase 2 + transaction lifecycle
+
+Phase 2 builds `Builders<BsonDocument>.Filter.In("_id", ids)` and runs the existing
+`deleteMany` / `updateMany`. For update, `BuildUpdate` is reused unchanged — setters (`$set` /
+pipeline, constant / self-referencing) are orthogonal to the source shape.
+
+Session acquisition:
+
+1. **Ambient `CurrentTransaction` (a `MongoTransaction`) present** → use its `Session` for both
+   phases; do not commit or abort (the user owns the transaction).
+2. **No ambient transaction, `AutoTransactionBehavior != Never`** → start a client session, call
+   `StartTransaction`, run both phases, `CommitTransaction` on success, `AbortTransaction` on
+   exception, and dispose the session.
+3. **No ambient transaction, `AutoTransactionBehavior == Never`** → throw an `InvalidOperationException`
+   instructing the user to open an explicit transaction around this bulk shape.
+4. **Deployment without transaction support** → throw an actionable `InvalidOperationException`
+   naming the requirement (a transaction-capable deployment). Where feasible this is detected before
+   issuing writes; otherwise the driver's transaction-unsupported error is wrapped with the same
+   guidance.
+
+Phase 1 runs **inside** the transaction scope so it and phase 2 observe one snapshot — a non-empty
+phase 1 evaluated outside a transaction and then deleted inside one would reopen the race the
+transaction is meant to close. An empty phase 1 therefore still sits inside the (auto-started)
+transaction; it simply skips phase 2 and commits a no-op, returning 0.
+
+The architecture note already in the file (bulk executors call the driver collection directly and
+read the ambient session, a deliberate narrow exception to "Query never touches the driver") is
+extended to cover phase 1's read and the auto-started transaction.
+
+### Count semantics
+
+Return the phase-2 result count (`DeletedCount` / `MatchedCount`) under the existing
+`checked((int))` overflow contract. Inside the transaction, phases 1 and 2 observe a consistent
+snapshot, so the count reflects the targeted set. (Without the transaction, a concurrent delete
+between phases could shrink the count — which is the race the transaction closes.) `Take(0)` /
+empty phase 1 returns 0 (committing a no-op transaction when one was auto-started).
+
+### Diagnostics
+
+The two-phase executor logs through the existing `ExecutingBulkDelete` / `ExecutedBulkDelete` /
+`ExecutingBulkUpdate` / `ExecutedBulkUpdate` events, with a detail indicating two-phase execution
+and the resolved target count, so the extra read round-trip is observable. No new event IDs — the
+registry stays stable.
+
+## Testing
+
+- **Functional** (`FunctionalTests/Query/ExecuteDeleteTests`, `ExecuteUpdateTests`): add
+  `OrderBy + Take`, `Skip + Take`, `Distinct`, and ordered-update cases; assert affected counts and
+  post-state. Assert the auto-started transaction commits on success and rolls back on a forced
+  failure (no partial effect). Add a `Where`-only regression asserting **no** transaction is started
+  (single-command path preserved).
+- **Transaction policy**: a test for `AutoTransactionBehavior.Never` (clear throw, no write issued)
+  and a standalone-deployment error test (skipped/guarded when the test server is a replica set, per
+  `TestServer` conditions).
+- **Specification suite**: re-examine the `NorthwindBulkUpdates` cases tagged `EF-X016` — the
+  `OrderBy`/`Skip`/`Take`/`Distinct`-scoped ones should now pass via two-phase. Move those from
+  run-and-assert-failure to `base` (green) and update `docs/failing-spec-tests.md` (`EF-X016` shrinks
+  to the join/group/set-op shapes only).
+- **Unit** (`UnitTests/Query/Expressions/MongoNonQueryExpressionTests`): cover the new `Strategy`
+  classification.
+- **Multi-EF**: `/test-all` across EF8 (still rejects bulk), EF9, EF10.
+
+## Risks & mitigations
+
+- **Phase-1 / phase-2 divergence without a transaction** — closed by running both phases in one
+  transaction; the `Never` and standalone cases throw rather than silently racing.
+- **Phase-1 projection cost** — phase 1 transfers only `_id`s, not full documents; large target sets
+  produce a large `$in`, which is the inherent cost of the emulation and is documented.
+- **Behavior drift from the read path** — avoided by reusing `TranslateQuery` / the driver for all
+  operator translation rather than hand-building the phase-1 pipeline.
+- **EF version skew** — entirely under `#if !EF8`; no new public surface, so no breaking-change
+  exposure.

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoBulkWriteEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoBulkWriteEventData.cs
@@ -46,6 +46,33 @@ public class MongoBulkWriteEventData : EventData
         long insertCount,
         long deleteCount,
         long modifyCount)
+        : this(eventDefinition, messageGenerator, elapsed, collectionNamespace, insertCount, deleteCount, modifyCount, targetCount: null)
+    {
+    }
+
+    /// <summary>
+    /// Constructs the event payload for a two-phase bulk operation.
+    /// </summary>
+    /// <param name="eventDefinition">The event definition.</param>
+    /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>
+    /// <param name="elapsed">The time elapsed since the command was sent to the database.</param>
+    /// <param name="collectionNamespace">The <see cref="CollectionNamespace"/> being operated upon.</param>
+    /// <param name="insertCount">The number of documents to insert in this bulk write operation.</param>
+    /// <param name="deleteCount">The number of documents to delete by this bulk write operation.</param>
+    /// <param name="modifyCount">The number of documents to modify by this bulk write operation.</param>
+    /// <param name="targetCount">
+    /// For a two-phase bulk delete/update — the number of documents identified in phase one to be acted on
+    /// by <c>_id</c>; <see langword="null" /> for single-command bulk writes.
+    /// </param>
+    public MongoBulkWriteEventData(
+        EventDefinitionBase eventDefinition,
+        Func<EventDefinitionBase, EventData, string> messageGenerator,
+        TimeSpan elapsed,
+        CollectionNamespace collectionNamespace,
+        long insertCount,
+        long deleteCount,
+        long modifyCount,
+        int? targetCount)
         : base(eventDefinition, messageGenerator)
     {
         Elapsed = elapsed;
@@ -53,6 +80,7 @@ public class MongoBulkWriteEventData : EventData
         InsertCount = insertCount;
         DeleteCount = deleteCount;
         ModifyCount = modifyCount;
+        TargetCount = targetCount;
     }
 
     /// <summary>
@@ -79,4 +107,10 @@ public class MongoBulkWriteEventData : EventData
     /// The number of documents to modify by this bulk write operation.
     /// </summary>
     public long ModifyCount { get; }
+
+    /// <summary>
+    /// For a two-phase bulk delete/update — the number of documents identified in phase one to be acted on
+    /// by <c>_id</c>; <see langword="null" /> for single-command bulk writes.
+    /// </summary>
+    public int? TargetCount { get; }
 }

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoEventId.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoEventId.cs
@@ -51,6 +51,10 @@ public static class MongoEventId
         VectorSearchReturnedZeroResults,
         WaitingForVectorIndex,
         WaitingForSearchIndex,
+        ExecutingBulkDelete,
+        ExecutedBulkDelete,
+        ExecutingBulkUpdate,
+        ExecutedBulkUpdate,
     }
 
     private static EventId MakeDatabaseCommandId(Id id)
@@ -236,4 +240,48 @@ public static class MongoEventId
     ///     <para>This event uses the <see cref="TimeSpanEventData" /> payload when used with a <see cref="DiagnosticSource" />.</para>
     /// </remarks>
     public static readonly EventId WaitingForSearchIndex = MakeDatabaseId(Id.WaitingForSearchIndex);
+
+    /// <summary>
+    /// A bulk delete (server-side <c>ExecuteDelete</c>) is being executed.
+    /// </summary>
+    /// <remarks>
+    /// <para>This event is in the <see cref="DbLoggerCategory.Update" /> category.</para>
+    /// <para>
+    /// This event uses the <see cref="MongoBulkWriteEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    /// </para>
+    /// </remarks>
+    public static readonly EventId ExecutingBulkDelete = MakeUpdateId(Id.ExecutingBulkDelete);
+
+    /// <summary>
+    /// A bulk delete (server-side <c>ExecuteDelete</c>) has been executed.
+    /// </summary>
+    /// <remarks>
+    /// <para>This event is in the <see cref="DbLoggerCategory.Update" /> category.</para>
+    /// <para>
+    /// This event uses the <see cref="MongoBulkWriteEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    /// </para>
+    /// </remarks>
+    public static readonly EventId ExecutedBulkDelete = MakeUpdateId(Id.ExecutedBulkDelete);
+
+    /// <summary>
+    /// A bulk update (server-side <c>ExecuteUpdate</c>) is being executed.
+    /// </summary>
+    /// <remarks>
+    /// <para>This event is in the <see cref="DbLoggerCategory.Update" /> category.</para>
+    /// <para>
+    /// This event uses the <see cref="MongoBulkWriteEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    /// </para>
+    /// </remarks>
+    public static readonly EventId ExecutingBulkUpdate = MakeUpdateId(Id.ExecutingBulkUpdate);
+
+    /// <summary>
+    /// A bulk update (server-side <c>ExecuteUpdate</c>) has been executed.
+    /// </summary>
+    /// <remarks>
+    /// <para>This event is in the <see cref="DbLoggerCategory.Update" /> category.</para>
+    /// <para>
+    /// This event uses the <see cref="MongoBulkWriteEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    /// </para>
+    /// </remarks>
+    public static readonly EventId ExecutedBulkUpdate = MakeUpdateId(Id.ExecutedBulkUpdate);
 }

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerUpdateExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerUpdateExtensions.cs
@@ -22,6 +22,11 @@ using MongoDB.Driver;
 namespace MongoDB.EntityFrameworkCore.Diagnostics;
 
 using BulkWriteEventDefinition = EventDefinition<string, CollectionNamespace, long, long, long>;
+#if !EF8
+using BulkExecutingEventDefinition = EventDefinition<string, CollectionNamespace>;
+using BulkExecutingTwoPhaseEventDefinition = EventDefinition<string, CollectionNamespace, int>;
+using BulkExecutedEventDefinition = EventDefinition<string, CollectionNamespace, long>;
+#endif
 
 /// <summary>
 /// MongoDB-specific logging extensions for operations in the Update category.
@@ -171,4 +176,338 @@ internal static class MongoLoggerUpdateExtensions
                         level,
                         MongoEventId.ExecutedBulkWrite,
                         "Executed Bulk Write ({elapsed} ms) Collection='{collectionNamespace}', Inserted={inserted}, Deleted={deleted}, Modified={modified}"))));
+
+#if !EF8
+    /// <summary>
+    /// Logs for the <see cref="MongoEventId.ExecutingBulkDelete" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="duration">The amount of time the operation took.</param>
+    /// <param name="collectionNamespace">The <see cref="CollectionNamespace"/> this operation is using.</param>
+    /// <param name="targetCount">
+    /// When non-null, indicates that this is a two-phase bulk delete and specifies the number of
+    /// target document ids collected in phase 1.
+    /// </param>
+    public static void ExecutingBulkDelete(
+        this IDiagnosticsLogger<DbLoggerCategory.Update> diagnostics,
+        TimeSpan duration,
+        CollectionNamespace collectionNamespace,
+        int? targetCount = null)
+    {
+        if (targetCount.HasValue)
+        {
+            var twoPhaseDefinition = LogExecutingBulkDeleteTwoPhase(diagnostics);
+
+            if (diagnostics.ShouldLog(twoPhaseDefinition))
+            {
+                twoPhaseDefinition.Log(diagnostics, duration.TotalMilliseconds.ToString(), collectionNamespace, targetCount.Value);
+            }
+
+            if (diagnostics.NeedsEventData(twoPhaseDefinition, out var diagnosticSourceEnabled2, out var simpleLogEnabled2))
+            {
+                var twoPhaseEventData = new MongoBulkWriteEventData(
+                    twoPhaseDefinition,
+                    ExecutingBulkDeleteTwoPhaseMessage,
+                    duration,
+                    collectionNamespace,
+                    insertCount: 0,
+                    deleteCount: 0,
+                    modifyCount: 0,
+                    targetCount: targetCount.Value);
+
+                diagnostics.DispatchEventData(twoPhaseDefinition, twoPhaseEventData, diagnosticSourceEnabled2, simpleLogEnabled2);
+            }
+
+            return;
+        }
+
+        var definition = LogExecutingBulkDelete(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, duration.TotalMilliseconds.ToString(), collectionNamespace);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new MongoBulkWriteEventData(
+                definition,
+                ExecutingBulkDeleteMessage,
+                duration,
+                collectionNamespace,
+                insertCount: 0,
+                deleteCount: 0,
+                modifyCount: 0);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string ExecutingBulkDeleteMessage(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (BulkExecutingEventDefinition)definition;
+        var p = (MongoBulkWriteEventData)payload;
+        return d.GenerateMessage(p.Elapsed.TotalMilliseconds.ToString(), p.CollectionNamespace);
+    }
+
+    private static string ExecutingBulkDeleteTwoPhaseMessage(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (BulkExecutingTwoPhaseEventDefinition)definition;
+        var p = (MongoBulkWriteEventData)payload;
+        return d.GenerateMessage(p.Elapsed.TotalMilliseconds.ToString(), p.CollectionNamespace, p.TargetCount!.Value);
+    }
+
+    private static BulkExecutingEventDefinition LogExecutingBulkDelete(IDiagnosticsLogger logger)
+        => (BulkExecutingEventDefinition)
+            (((MongoLoggingDefinitions)logger.Definitions).LogExecutingBulkDelete ?? NonCapturingLazyInitializer.EnsureInitialized(
+                ref ((MongoLoggingDefinitions)logger.Definitions).LogExecutingBulkDelete,
+                logger,
+                static logger => new BulkExecutingEventDefinition(
+                    logger.Options,
+                    MongoEventId.ExecutingBulkDelete,
+                    LogLevel.Information,
+                    "MongoEventId.ExecutingBulkDelete",
+                    level => LoggerMessage.Define<string, CollectionNamespace>(
+                        level,
+                        MongoEventId.ExecutingBulkDelete,
+                        "Executing Bulk Delete ({elapsed} ms) Collection='{collectionNamespace}'"))));
+
+    private static BulkExecutingTwoPhaseEventDefinition LogExecutingBulkDeleteTwoPhase(IDiagnosticsLogger logger)
+        => (BulkExecutingTwoPhaseEventDefinition)
+            (((MongoLoggingDefinitions)logger.Definitions).LogExecutingBulkDeleteTwoPhase ?? NonCapturingLazyInitializer.EnsureInitialized(
+                ref ((MongoLoggingDefinitions)logger.Definitions).LogExecutingBulkDeleteTwoPhase,
+                logger,
+                static logger => new BulkExecutingTwoPhaseEventDefinition(
+                    logger.Options,
+                    MongoEventId.ExecutingBulkDelete,
+                    LogLevel.Information,
+                    "MongoEventId.ExecutingBulkDelete",
+                    level => LoggerMessage.Define<string, CollectionNamespace, int>(
+                        level,
+                        MongoEventId.ExecutingBulkDelete,
+                        "Executing Bulk Delete ({elapsed} ms) Collection='{collectionNamespace}' (two-phase, {targetCount} target(s))"))));
+
+    /// <summary>
+    /// Logs for the <see cref="MongoEventId.ExecutedBulkDelete" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="duration">The amount of time the operation took.</param>
+    /// <param name="collectionNamespace">The <see cref="CollectionNamespace"/> this operation is using.</param>
+    /// <param name="deleteCount">The number of documents deleted.</param>
+    public static void ExecutedBulkDelete(
+        this IDiagnosticsLogger<DbLoggerCategory.Update> diagnostics,
+        TimeSpan duration,
+        CollectionNamespace collectionNamespace,
+        long deleteCount)
+    {
+        var definition = LogExecutedBulkDelete(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, duration.TotalMilliseconds.ToString(), collectionNamespace, deleteCount);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new MongoBulkWriteEventData(
+                definition,
+                ExecutedBulkDeleteMessage,
+                duration,
+                collectionNamespace,
+                insertCount: 0,
+                deleteCount: deleteCount,
+                modifyCount: 0);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string ExecutedBulkDeleteMessage(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (BulkExecutedEventDefinition)definition;
+        var p = (MongoBulkWriteEventData)payload;
+        return d.GenerateMessage(p.Elapsed.TotalMilliseconds.ToString(), p.CollectionNamespace, p.DeleteCount);
+    }
+
+    private static BulkExecutedEventDefinition LogExecutedBulkDelete(IDiagnosticsLogger logger)
+        => (BulkExecutedEventDefinition)
+            (((MongoLoggingDefinitions)logger.Definitions).LogExecutedBulkDelete ?? NonCapturingLazyInitializer.EnsureInitialized(
+                ref ((MongoLoggingDefinitions)logger.Definitions).LogExecutedBulkDelete,
+                logger,
+                static logger => new BulkExecutedEventDefinition(
+                    logger.Options,
+                    MongoEventId.ExecutedBulkDelete,
+                    LogLevel.Information,
+                    "MongoEventId.ExecutedBulkDelete",
+                    level => LoggerMessage.Define<string, CollectionNamespace, long>(
+                        level,
+                        MongoEventId.ExecutedBulkDelete,
+                        "Executed Bulk Delete ({elapsed} ms) Collection='{collectionNamespace}', Deleted={deleted}"))));
+
+    /// <summary>
+    /// Logs for the <see cref="MongoEventId.ExecutingBulkUpdate" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="duration">The amount of time the operation took.</param>
+    /// <param name="collectionNamespace">The <see cref="CollectionNamespace"/> this operation is using.</param>
+    /// <param name="targetCount">
+    /// When non-null, indicates that this is a two-phase bulk update and specifies the number of
+    /// target document ids collected in phase 1.
+    /// </param>
+    public static void ExecutingBulkUpdate(
+        this IDiagnosticsLogger<DbLoggerCategory.Update> diagnostics,
+        TimeSpan duration,
+        CollectionNamespace collectionNamespace,
+        int? targetCount = null)
+    {
+        if (targetCount.HasValue)
+        {
+            var twoPhaseDefinition = LogExecutingBulkUpdateTwoPhase(diagnostics);
+
+            if (diagnostics.ShouldLog(twoPhaseDefinition))
+            {
+                twoPhaseDefinition.Log(diagnostics, duration.TotalMilliseconds.ToString(), collectionNamespace, targetCount.Value);
+            }
+
+            if (diagnostics.NeedsEventData(twoPhaseDefinition, out var diagnosticSourceEnabled2, out var simpleLogEnabled2))
+            {
+                var twoPhaseEventData = new MongoBulkWriteEventData(
+                    twoPhaseDefinition,
+                    ExecutingBulkUpdateTwoPhaseMessage,
+                    duration,
+                    collectionNamespace,
+                    insertCount: 0,
+                    deleteCount: 0,
+                    modifyCount: 0,
+                    targetCount: targetCount.Value);
+
+                diagnostics.DispatchEventData(twoPhaseDefinition, twoPhaseEventData, diagnosticSourceEnabled2, simpleLogEnabled2);
+            }
+
+            return;
+        }
+
+        var definition = LogExecutingBulkUpdate(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, duration.TotalMilliseconds.ToString(), collectionNamespace);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new MongoBulkWriteEventData(
+                definition,
+                ExecutingBulkUpdateMessage,
+                duration,
+                collectionNamespace,
+                insertCount: 0,
+                deleteCount: 0,
+                modifyCount: 0);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string ExecutingBulkUpdateMessage(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (BulkExecutingEventDefinition)definition;
+        var p = (MongoBulkWriteEventData)payload;
+        return d.GenerateMessage(p.Elapsed.TotalMilliseconds.ToString(), p.CollectionNamespace);
+    }
+
+    private static string ExecutingBulkUpdateTwoPhaseMessage(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (BulkExecutingTwoPhaseEventDefinition)definition;
+        var p = (MongoBulkWriteEventData)payload;
+        return d.GenerateMessage(p.Elapsed.TotalMilliseconds.ToString(), p.CollectionNamespace, p.TargetCount!.Value);
+    }
+
+    private static BulkExecutingEventDefinition LogExecutingBulkUpdate(IDiagnosticsLogger logger)
+        => (BulkExecutingEventDefinition)
+            (((MongoLoggingDefinitions)logger.Definitions).LogExecutingBulkUpdate ?? NonCapturingLazyInitializer.EnsureInitialized(
+                ref ((MongoLoggingDefinitions)logger.Definitions).LogExecutingBulkUpdate,
+                logger,
+                static logger => new BulkExecutingEventDefinition(
+                    logger.Options,
+                    MongoEventId.ExecutingBulkUpdate,
+                    LogLevel.Information,
+                    "MongoEventId.ExecutingBulkUpdate",
+                    level => LoggerMessage.Define<string, CollectionNamespace>(
+                        level,
+                        MongoEventId.ExecutingBulkUpdate,
+                        "Executing Bulk Update ({elapsed} ms) Collection='{collectionNamespace}'"))));
+
+    private static BulkExecutingTwoPhaseEventDefinition LogExecutingBulkUpdateTwoPhase(IDiagnosticsLogger logger)
+        => (BulkExecutingTwoPhaseEventDefinition)
+            (((MongoLoggingDefinitions)logger.Definitions).LogExecutingBulkUpdateTwoPhase ?? NonCapturingLazyInitializer.EnsureInitialized(
+                ref ((MongoLoggingDefinitions)logger.Definitions).LogExecutingBulkUpdateTwoPhase,
+                logger,
+                static logger => new BulkExecutingTwoPhaseEventDefinition(
+                    logger.Options,
+                    MongoEventId.ExecutingBulkUpdate,
+                    LogLevel.Information,
+                    "MongoEventId.ExecutingBulkUpdate",
+                    level => LoggerMessage.Define<string, CollectionNamespace, int>(
+                        level,
+                        MongoEventId.ExecutingBulkUpdate,
+                        "Executing Bulk Update ({elapsed} ms) Collection='{collectionNamespace}' (two-phase, {targetCount} target(s))"))));
+
+    /// <summary>
+    /// Logs for the <see cref="MongoEventId.ExecutedBulkUpdate" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="duration">The amount of time the operation took.</param>
+    /// <param name="collectionNamespace">The <see cref="CollectionNamespace"/> this operation is using.</param>
+    /// <param name="modifyCount">The number of documents modified.</param>
+    public static void ExecutedBulkUpdate(
+        this IDiagnosticsLogger<DbLoggerCategory.Update> diagnostics,
+        TimeSpan duration,
+        CollectionNamespace collectionNamespace,
+        long modifyCount)
+    {
+        var definition = LogExecutedBulkUpdate(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, duration.TotalMilliseconds.ToString(), collectionNamespace, modifyCount);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new MongoBulkWriteEventData(
+                definition,
+                ExecutedBulkUpdateMessage,
+                duration,
+                collectionNamespace,
+                insertCount: 0,
+                deleteCount: 0,
+                modifyCount: modifyCount);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string ExecutedBulkUpdateMessage(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (BulkExecutedEventDefinition)definition;
+        var p = (MongoBulkWriteEventData)payload;
+        return d.GenerateMessage(p.Elapsed.TotalMilliseconds.ToString(), p.CollectionNamespace, p.ModifyCount);
+    }
+
+    private static BulkExecutedEventDefinition LogExecutedBulkUpdate(IDiagnosticsLogger logger)
+        => (BulkExecutedEventDefinition)
+            (((MongoLoggingDefinitions)logger.Definitions).LogExecutedBulkUpdate ?? NonCapturingLazyInitializer.EnsureInitialized(
+                ref ((MongoLoggingDefinitions)logger.Definitions).LogExecutedBulkUpdate,
+                logger,
+                static logger => new BulkExecutedEventDefinition(
+                    logger.Options,
+                    MongoEventId.ExecutedBulkUpdate,
+                    LogLevel.Information,
+                    "MongoEventId.ExecutedBulkUpdate",
+                    level => LoggerMessage.Define<string, CollectionNamespace, long>(
+                        level,
+                        MongoEventId.ExecutedBulkUpdate,
+                        "Executed Bulk Update ({elapsed} ms) Collection='{collectionNamespace}', Modified={modified}"))));
+#endif
 }

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggingDefinitions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggingDefinitions.cs
@@ -27,6 +27,16 @@ internal class MongoLoggingDefinitions : LoggingDefinitions
     public EventDefinitionBase? LogExecutingBulkWrite;
     public EventDefinitionBase? LogExecutedBulkWrite;
 
+#if !EF8
+    public EventDefinitionBase? LogExecutingBulkDelete;
+    public EventDefinitionBase? LogExecutingBulkDeleteTwoPhase;
+    public EventDefinitionBase? LogExecutedBulkDelete;
+
+    public EventDefinitionBase? LogExecutingBulkUpdate;
+    public EventDefinitionBase? LogExecutingBulkUpdateTwoPhase;
+    public EventDefinitionBase? LogExecutedBulkUpdate;
+#endif
+
     public EventDefinitionBase? LogBeginningTransaction;
     public EventDefinitionBase? LogBeganTransaction;
 

--- a/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
+++ b/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="MongoDB.EntityFrameworkCore.UnitTests" />
     <InternalsVisibleTo Include="MongoDB.EntityFrameworkCore.SpecificationTests" />
+    <InternalsVisibleTo Include="MongoDB.EntityFrameworkCore.FunctionalTests" />
     <PackageReference Remove="Microsoft.SourceLink.GitHub" />
     <PackageReference Include="MongoDB.Driver" Version="$(CSharpDriverVersion)" />
   </ItemGroup>

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoNonQueryExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoNonQueryExpression.cs
@@ -1,0 +1,77 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace MongoDB.EntityFrameworkCore.Query.Expressions;
+
+/// <summary>
+/// Marker node produced by ExecuteDelete / ExecuteUpdate translation. Carries the source
+/// query (collection + captured predicate chain) and, for updates, the ordered setters.
+/// Recognized by <see cref="Visitors.MongoShapedQueryCompilingExpressionVisitor"/>.
+/// </summary>
+internal sealed class MongoNonQueryExpression : Expression
+{
+    public enum OperationKind { Delete, Update }
+
+    public enum BulkStrategy { SingleCommand, TwoPhase }
+
+    public sealed record Setter(IProperty Property, Expression ValueExpression, bool IsSelfReferencing);
+
+    public MongoNonQueryExpression(MongoQueryExpression sourceQuery, BulkStrategy strategy = BulkStrategy.SingleCommand)
+    {
+        SourceQuery = sourceQuery;
+        Kind = OperationKind.Delete;
+        Setters = [];
+        Strategy = strategy;
+    }
+
+    public MongoNonQueryExpression(
+        MongoQueryExpression sourceQuery,
+        IReadOnlyList<Setter> setters,
+        BulkStrategy strategy = BulkStrategy.SingleCommand)
+    {
+        SourceQuery = sourceQuery;
+        Kind = OperationKind.Update;
+        Setters = setters;
+        Strategy = strategy;
+    }
+
+    public MongoQueryExpression SourceQuery { get; }
+    public OperationKind Kind { get; }
+    public IReadOnlyList<Setter> Setters { get; }
+    public BulkStrategy Strategy { get; }
+
+    /// <summary>
+    /// Unwraps the leading ExecuteDelete / ExecuteUpdate marker call (declared on
+    /// <see cref="EntityFrameworkQueryableExtensions"/>) from a captured method chain, returning the underlying
+    /// source query (e.g. <c>root.Where(...)</c>). EF captures the full chain including the bulk operator as the
+    /// <see cref="MongoQueryExpression.CapturedExpression"/>; walkers that scope the operation need only the source.
+    /// </summary>
+    public static Expression? UnwrapBulkOperator(Expression? capturedExpression)
+        => capturedExpression is MethodCallExpression { Method.DeclaringType: var declaringType } call
+           && declaringType == typeof(EntityFrameworkQueryableExtensions)
+            ? call.Arguments[0]
+            : capturedExpression;
+
+    public override ExpressionType NodeType => ExpressionType.Extension;
+    public override System.Type Type => typeof(int);
+    public override bool CanReduce => false;
+
+    protected override Expression VisitChildren(System.Linq.Expressions.ExpressionVisitor visitor) => this;
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -14,6 +14,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -79,6 +81,12 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
     {
         var method = methodCallExpression.Method;
+#if !EF8
+        // ExecuteDelete / ExecuteUpdate marker methods are declared on EntityFrameworkQueryableExtensions.
+        // Let them through to the base, which dispatches to TranslateExecuteDelete / TranslateExecuteUpdate.
+        if (method.DeclaringType == typeof(EntityFrameworkQueryableExtensions))
+            return base.VisitMethodCall(methodCallExpression);
+#endif
         if (!AllowedQueryableExtensions.Contains(method.DeclaringType))
             return QueryCompilationContext.NotTranslatedExpression;
 
@@ -176,6 +184,248 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
                 new ProjectionBindingExpression(queryExpression, new ProjectionMember(), typeof(ValueBuffer)),
                 false));
     }
+
+#if !EF8
+    protected override Expression? TranslateExecuteDelete(ShapedQueryExpression source)
+    {
+        var mongoQueryExpression = (MongoQueryExpression)source.QueryExpression;
+        var strategy = ClassifyBulkSource(mongoQueryExpression);
+        return new MongoNonQueryExpression(mongoQueryExpression, strategy);
+    }
+
+#if EF10
+    protected override Expression? TranslateExecuteUpdate(
+        ShapedQueryExpression source,
+        IReadOnlyList<ExecuteUpdateSetter> setters)
+    {
+        var mongoQueryExpression = (MongoQueryExpression)source.QueryExpression;
+        var strategy = ClassifyBulkSource(mongoQueryExpression);
+        var parsed = setters
+            .Select(s => BuildSetter(mongoQueryExpression, s.PropertySelector, s.ValueExpression))
+            .ToList();
+        return new MongoNonQueryExpression(mongoQueryExpression, parsed, strategy);
+    }
+#else
+    protected override Expression? TranslateExecuteUpdate(
+        ShapedQueryExpression source,
+        LambdaExpression setPropertyCalls)
+    {
+        var mongoQueryExpression = (MongoQueryExpression)source.QueryExpression;
+        var strategy = ClassifyBulkSource(mongoQueryExpression);
+
+        var parsed = new List<MongoNonQueryExpression.Setter>();
+        var body = setPropertyCalls.Body;
+        // The chain is built outer-to-inner: s.SetProperty(a).SetProperty(b) parses as
+        // (s.SetProperty(a)).SetProperty(b) — so walk Object inward, inserting at the front
+        // to preserve the user's authored order.
+        while (body is MethodCallExpression { Method.Name: "SetProperty" } call)
+        {
+            var selector = call.Arguments[0].UnwrapLambdaFromQuote();
+            // For the self-referencing SetProperty overload the value arg is a quoted Func<T,TProp>
+            // lambda; for the constant overload it is the value expression directly.
+            var value = call.Arguments[1];
+            parsed.Insert(0, BuildSetter(mongoQueryExpression, selector, value));
+            body = call.Object!;
+        }
+
+        // EF10 validates "at least one SetProperty" before reaching the provider, but EF9 hands the raw
+        // lambda straight through — so a setter lambda with no SetProperty call (e.g. an empty body or an
+        // unrelated invocation) must be rejected here rather than silently running a no-op updateMany.
+        if (parsed.Count == 0)
+        {
+            AddTranslationErrorDetails(
+                "An 'ExecuteUpdate' call must specify at least one 'SetProperty' invocation, "
+                + "to indicate the properties to be updated.");
+            throw new InvalidOperationException(
+                CoreStrings.NonQueryTranslationFailedWithDetails(
+                    mongoQueryExpression.CapturedExpression?.Print(), TranslationErrorDetails));
+        }
+
+        return new MongoNonQueryExpression(mongoQueryExpression, parsed, strategy);
+    }
+#endif
+
+    /// <summary>
+    /// Parses a single <c>SetProperty(selector, value)</c> into a <see cref="MongoNonQueryExpression.Setter"/>.
+    /// The selector must target a mapped root scalar property of the entity; the value is classified as
+    /// self-referencing (references the entity) or a constant. Unsupported targets (owned / navigation /
+    /// unmapped) produce EF's canonical non-query translation failure.
+    /// </summary>
+    private MongoNonQueryExpression.Setter BuildSetter(
+        MongoQueryExpression mongoQueryExpression,
+        LambdaExpression propertySelector,
+        Expression valueExpression)
+    {
+        var entityType = mongoQueryExpression.CollectionExpression.EntityType;
+
+        var selectorBody = propertySelector.Body;
+        while (selectorBody is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } convert)
+        {
+            selectorBody = convert.Operand;
+        }
+
+        IProperty? property = null;
+        if (selectorBody is MemberExpression { Expression: var memberSource } member
+            && memberSource != null
+            && propertySelector.Parameters.Count == 1
+            && IsParameterReference(memberSource, propertySelector.Parameters[0]))
+        {
+            property = entityType.FindProperty(member.Member.Name);
+        }
+        // Also accept an EF.Property<TProperty>(entity, "Name") selector, e.g.
+        // SetProperty(c => EF.Property<string>(c, "ContactName"), ...).
+        else if (selectorBody is MethodCallExpression efPropertyCall
+                 && efPropertyCall.Method.IsEFPropertyMethod()
+                 && propertySelector.Parameters.Count == 1
+                 && IsParameterReference(efPropertyCall.Arguments[0], propertySelector.Parameters[0])
+                 && efPropertyCall.Arguments[1] is ConstantExpression { Value: string efPropertyName })
+        {
+            property = entityType.FindProperty(efPropertyName);
+        }
+
+        if (property == null)
+        {
+            AddTranslationErrorDetails(
+                "Only mapped root scalar properties can be updated by a bulk update. The setter target "
+                + $"'{propertySelector.Body}' is not a mapped scalar property of '{entityType.DisplayName()}'.");
+            throw new InvalidOperationException(
+                CoreStrings.NonQueryTranslationFailedWithDetails(
+                    mongoQueryExpression.CapturedExpression?.Print(), TranslationErrorDetails));
+        }
+
+        // Classify and normalize the value expression.
+        // EF9 self-referencing: value is a quoted Func<T,TProp> lambda; unwrap and detect a reference to its parameter.
+        // EF10 (and EF9 constants): value is the raw value/aggregate expression; detect a reference to the
+        // setter's lambda parameter.
+        bool isSelfReferencing;
+        Expression value;
+        if (IsQuotedLambda(valueExpression))
+        {
+            var valueLambda = valueExpression.UnwrapLambdaFromQuote();
+            value = valueLambda.Body;
+            isSelfReferencing = ParameterFinder.ContainsAny(value, valueLambda.Parameters);
+        }
+        else
+        {
+            value = valueExpression;
+            isSelfReferencing = ParameterFinder.ContainsAny(value, propertySelector.Parameters);
+        }
+
+        if (isSelfReferencing && property.GetTypeMapping().Converter != null)
+        {
+            AddTranslationErrorDetails(
+                $"Self-referencing ExecuteUpdate on property '{property.Name}' is not supported because it uses a value converter.");
+            throw new InvalidOperationException(
+                CoreStrings.NonQueryTranslationFailedWithDetails(
+                    mongoQueryExpression.CapturedExpression?.Print(), TranslationErrorDetails));
+        }
+
+        return new MongoNonQueryExpression.Setter(property, value, isSelfReferencing);
+    }
+
+    private static bool IsQuotedLambda(Expression expression)
+        => expression is LambdaExpression
+           || expression is UnaryExpression { NodeType: ExpressionType.Quote, Operand: LambdaExpression };
+
+    private static bool IsParameterReference(Expression expression, ParameterExpression parameter)
+    {
+        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } convert)
+        {
+            expression = convert.Operand;
+        }
+
+        return expression == parameter;
+    }
+
+    /// <summary>
+    /// Scans an expression for a reference to any of the supplied <see cref="ParameterExpression"/>s,
+    /// used to classify a bulk-update setter value as self-referencing (depends on the entity being updated).
+    /// </summary>
+    private sealed class ParameterFinder : ExpressionVisitor
+    {
+        private readonly IReadOnlyCollection<ParameterExpression> _parameters;
+        private bool _found;
+
+        private ParameterFinder(IReadOnlyCollection<ParameterExpression> parameters)
+            => _parameters = parameters;
+
+        public static bool ContainsAny(Expression expression, IReadOnlyCollection<ParameterExpression> parameters)
+        {
+            var finder = new ParameterFinder(parameters);
+            finder.Visit(expression);
+            return finder._found;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            if (_parameters.Contains(node))
+            {
+                _found = true;
+            }
+
+            return base.VisitParameter(node);
+        }
+    }
+
+    /// <summary>
+    /// Classifies the captured source chain of a bulk delete/update. A chain of only
+    /// <see cref="Queryable.Where{TSource}(IQueryable{TSource},Expression{Func{TSource,bool}})"/> is the
+    /// single-command atomic path. Adding <c>OrderBy</c>/<c>OrderByDescending</c>/<c>ThenBy</c>/
+    /// <c>ThenByDescending</c>/<c>Skip</c>/<c>Take</c>/<c>Distinct</c> requires the two-phase
+    /// (query target <c>_id</c>s, then act by <c>$in</c>) path. Any other operator is not expressible as
+    /// a server-side bulk scope and produces EF's canonical non-query translation failure. A TPH
+    /// discriminator filter rides along as a Where.
+    /// </summary>
+    private MongoNonQueryExpression.BulkStrategy ClassifyBulkSource(MongoQueryExpression mongoQueryExpression)
+    {
+        var expression = MongoNonQueryExpression.UnwrapBulkOperator(mongoQueryExpression.CapturedExpression);
+        var strategy = MongoNonQueryExpression.BulkStrategy.SingleCommand;
+
+        while (expression is MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method.DeclaringType != typeof(Queryable))
+            {
+                ThrowBulkSourceNotSupported(mongoQueryExpression, methodCallExpression.Method.Name);
+            }
+
+            switch (methodCallExpression.Method.Name)
+            {
+                case nameof(Queryable.Where):
+                    break;
+
+                case nameof(Queryable.OrderBy):
+                case nameof(Queryable.OrderByDescending):
+                case nameof(Queryable.ThenBy):
+                case nameof(Queryable.ThenByDescending):
+                case nameof(Queryable.Skip):
+                case nameof(Queryable.Take):
+                case nameof(Queryable.Distinct):
+                    strategy = MongoNonQueryExpression.BulkStrategy.TwoPhase;
+                    break;
+
+                default:
+                    ThrowBulkSourceNotSupported(mongoQueryExpression, methodCallExpression.Method.Name);
+                    break;
+            }
+
+            expression = methodCallExpression.Arguments[0];
+        }
+
+        return strategy;
+    }
+
+    [DoesNotReturn]
+    private void ThrowBulkSourceNotSupported(MongoQueryExpression mongoQueryExpression, string operatorName)
+    {
+        AddTranslationErrorDetails(
+            $"The '{operatorName}' operator is not supported in a bulk delete or update. Only 'Where' predicates "
+            + "and the 'OrderBy', 'OrderByDescending', 'ThenBy', 'ThenByDescending', 'Skip', 'Take', and 'Distinct' "
+            + "operators can scope a bulk operation.");
+        throw new InvalidOperationException(
+            CoreStrings.NonQueryTranslationFailedWithDetails(
+                mongoQueryExpression.CapturedExpression?.Print(), TranslationErrorDetails));
+    }
+#endif
 
     private static ResultCardinality GetResultCardinality(MethodInfo method)
     {

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -18,7 +18,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+#if !EF8
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+#endif
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using MongoDB.Bson;
@@ -56,6 +64,50 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         _threadSafetyChecksEnabled = dependencies.CoreSingletonOptions.AreThreadSafetyChecksEnabled;
         _bsonSerializerFactory = mongoDependencies.BsonSerializerFactory;
     }
+
+#if !EF8
+    /// <inheritdoc/>
+    protected override Expression VisitExtension(Expression extensionExpression)
+        => extensionExpression is MongoNonQueryExpression nonQueryExpression
+            ? VisitNonQuery(nonQueryExpression)
+            : base.VisitExtension(extensionExpression);
+
+    private Expression VisitNonQuery(MongoNonQueryExpression nonQueryExpression)
+    {
+        var entityType = nonQueryExpression.SourceQuery.CollectionExpression.EntityType;
+
+        if (nonQueryExpression.Strategy == MongoNonQueryExpression.BulkStrategy.TwoPhase)
+        {
+            // Two-phase: phase 1 materializes matched entities and extracts their stored _id,
+            // phase 2 deletes/updates by { _id: { $in: [...] } } — both inside a transaction. Works for
+            // scalar and composite primary keys because we read the raw _id BsonValue from the serialized doc.
+            EnsureBulkKeyOrThrow(entityType, nonQueryExpression);
+            var twoPhaseExecutor = nonQueryExpression.Kind == MongoNonQueryExpression.OperationKind.Update
+                ? (QueryCompilationContext.IsAsync ? ExecuteTwoPhaseUpdateAsyncMethodInfo : ExecuteTwoPhaseUpdateMethodInfo)
+                : (QueryCompilationContext.IsAsync ? ExecuteTwoPhaseDeleteAsyncMethodInfo : ExecuteTwoPhaseDeleteMethodInfo);
+            return Expression.Call(null,
+                twoPhaseExecutor.MakeGenericMethod(entityType.ClrType),
+                QueryCompilationContext.QueryContextParameter,
+                Expression.Constant(entityType),
+                Expression.Constant(_bsonSerializerFactory),
+                Expression.Constant(nonQueryExpression));
+        }
+
+        var executor = nonQueryExpression.Kind switch
+        {
+            MongoNonQueryExpression.OperationKind.Update =>
+                QueryCompilationContext.IsAsync ? ExecuteUpdateAsyncMethodInfo : ExecuteUpdateMethodInfo,
+            _ => QueryCompilationContext.IsAsync ? ExecuteDeleteAsyncMethodInfo : ExecuteDeleteMethodInfo
+        };
+
+        return Expression.Call(null,
+            executor.MakeGenericMethod(entityType.ClrType),
+            QueryCompilationContext.QueryContextParameter,
+            Expression.Constant(entityType),
+            Expression.Constant(_bsonSerializerFactory),
+            Expression.Constant(nonQueryExpression));
+    }
+#endif
 
     /// <inheritdoc/>
     protected override Expression VisitShapedQuery(ShapedQueryExpression shapedQueryExpression)
@@ -310,6 +362,764 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
             threadSafetyChecksEnabled,
             GetOnZeroResultsAction(queryExpression));
     }
+
+#if !EF8
+    // Architecture note: unlike the read path (which hands a MongoExecutableQuery to
+    // MongoClientWrapper.Execute in Storage), these bulk executors call DeleteMany/UpdateMany on the
+    // driver collection directly and read the ambient session from Database.CurrentTransaction. This is
+    // a deliberate, narrow exception to the "Query never touches the driver" boundary: ExecuteDelete/
+    // ExecuteUpdate have no cursor/shaper to run, the collection is still obtained via the wrapper
+    // (GetCollection), and the transaction lifecycle (begin/commit/rollback) remains entirely in
+    // Storage's transaction manager — only the existing session handle is read here. Routing the raw
+    // write through a new IMongoClientWrapper method would expand that observable interface for marginal
+    // benefit (the session would still be resolved from the query context). Revisit if bulk execution
+    // grows retry/cursor concerns that belong in the wrapper.
+
+    // Two-phase bulk needs phase 1 (read) and phase 2 (write) to observe one snapshot, so both run inside a
+    // single transaction. If the user already opened one we join it (and never commit it — they own it);
+    // otherwise we auto-start one, commit on success, abort on failure. AutoTransactionBehavior.Never means
+    // "I manage transactions" — we refuse to auto-start and tell the caller to open one.
+    private static int RunInBulkTransaction(QueryContext queryContext, MongoNonQueryExpression nonQuery, Func<int> body)
+    {
+        var database = queryContext.Context.Database;
+        if (database.CurrentTransaction != null)
+        {
+            return body();
+        }
+
+        if (database.AutoTransactionBehavior == AutoTransactionBehavior.Never)
+        {
+            throw NoAutoTransactionError();
+        }
+
+        // BeginTransaction is inside the try: on a non-transactional deployment the session's StartTransaction
+        // (reached synchronously via MongoTransaction.Start) throws here, and we want that mapped to the
+        // actionable StandaloneTransactionError like any other transaction-unsupported failure.
+        IDbContextTransaction? transaction = null;
+        try
+        {
+            transaction = database.BeginTransaction();
+            var result = body();
+            transaction.Commit();
+            return result;
+        }
+        catch (Exception exception)
+        {
+            if (transaction != null)
+            {
+                SafeRollback(transaction);
+            }
+
+            if (IsTransactionsUnsupported(exception))
+            {
+                throw StandaloneTransactionError(exception);
+            }
+
+            throw;
+        }
+        finally
+        {
+            transaction?.Dispose();
+        }
+    }
+
+    private static async Task<int> RunInBulkTransactionAsync(
+        QueryContext queryContext, MongoNonQueryExpression nonQuery, Func<Task<int>> body)
+    {
+        var database = queryContext.Context.Database;
+        if (database.CurrentTransaction != null)
+        {
+            return await body().ConfigureAwait(false);
+        }
+
+        if (database.AutoTransactionBehavior == AutoTransactionBehavior.Never)
+        {
+            throw NoAutoTransactionError();
+        }
+
+        var cancellationToken = queryContext.CancellationToken;
+        // BeginTransactionAsync is inside the try for the same reason as the sync path: a non-transactional
+        // deployment throws during transaction startup, and that must map to StandaloneTransactionError.
+        IDbContextTransaction? transaction = null;
+        try
+        {
+            transaction = await database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            var result = await body().ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+        catch (Exception exception)
+        {
+            if (transaction != null)
+            {
+                await SafeRollbackAsync(transaction, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (IsTransactionsUnsupported(exception))
+            {
+                throw StandaloneTransactionError(exception);
+            }
+
+            throw;
+        }
+        finally
+        {
+            if (transaction != null)
+            {
+                await transaction.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static void SafeRollback(IDbContextTransaction transaction)
+    {
+        try { transaction.Rollback(); }
+        catch { /* a failed/standalone transaction may not be rollback-able; the original error wins */ }
+    }
+
+    private static async Task SafeRollbackAsync(IDbContextTransaction transaction, CancellationToken cancellationToken)
+    {
+        try { await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false); }
+        catch { /* see SafeRollback */ }
+    }
+
+    private static InvalidOperationException NoAutoTransactionError()
+        => new(
+            "This bulk delete or update uses ordering, paging, or 'Distinct', which the MongoDB provider executes "
+            + "as a two-phase operation requiring a transaction. The context's AutoTransactionBehavior is 'Never', "
+            + "so open an explicit transaction (Database.BeginTransaction) around the call.");
+
+    private static InvalidOperationException StandaloneTransactionError(Exception inner)
+        => new(
+            "This bulk delete or update uses ordering, paging, or 'Distinct', which the MongoDB provider executes "
+            + "as a two-phase operation requiring a transaction. The current MongoDB deployment does not support "
+            + "multi-document transactions (a replica set or sharded cluster is required).", inner);
+
+    // Multi-document transactions are rejected when the deployment doesn't support them, and the failure can
+    // surface in three shapes: (1) the provider's own transaction startup (MongoTransaction.Start) intercepts the
+    // driver's "Standalone servers do not support transactions." and rethrows a NotSupportedException whose message
+    // contains "does not support transactions"; (2) a raw driver MongoCommandException (code 20 / IllegalOperation);
+    // (3) a "Transaction numbers are only allowed on a replica set member or mongos" message. Match all three so
+    // two-phase bulk on a non-transactional deployment is wrapped in the actionable StandaloneTransactionError.
+    // Match conservatively so unrelated failures propagate untouched.
+    private static bool IsTransactionsUnsupported(Exception exception)
+        => exception is MongoCommandException { Code: 20 }
+           || (exception is MongoException && exception.Message.Contains("Transaction numbers are only allowed", StringComparison.Ordinal))
+           || (exception is NotSupportedException && exception.Message.Contains("does not support transactions", StringComparison.Ordinal));
+
+    private static int ExecuteTwoPhaseDelete<TSource>(
+        QueryContext queryContext, IReadOnlyEntityType entityType, BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+        => RunInBulkTransaction(queryContext, nonQuery, () =>
+        {
+            var ids = SelectTargetIds<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+            return ids.Count == 0 ? 0 : DeleteByIds(queryContext, nonQuery, ids);
+        });
+
+    private static Task<int> ExecuteTwoPhaseDeleteAsync<TSource>(
+        QueryContext queryContext, IReadOnlyEntityType entityType, BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+        => RunInBulkTransactionAsync(queryContext, nonQuery, async () =>
+        {
+            var ids = await SelectTargetIdsAsync<TSource>(
+                queryContext, entityType, bsonSerializerFactory, nonQuery).ConfigureAwait(false);
+            return ids.Count == 0
+                ? 0
+                : await DeleteByIdsAsync(queryContext, nonQuery, ids).ConfigureAwait(false);
+        });
+
+    private static int ExecuteTwoPhaseUpdate<TSource>(
+        QueryContext queryContext, IReadOnlyEntityType entityType, BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+        => RunInBulkTransaction(queryContext, nonQuery, () =>
+        {
+            var ids = SelectTargetIds<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+            if (ids.Count == 0)
+            {
+                return 0;
+            }
+
+            var update = TranslateBulkOrThrow(nonQuery,
+                () => BuildUpdate<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery));
+            return UpdateByIds(queryContext, nonQuery, ids, update);
+        });
+
+    private static Task<int> ExecuteTwoPhaseUpdateAsync<TSource>(
+        QueryContext queryContext, IReadOnlyEntityType entityType, BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+        => RunInBulkTransactionAsync(queryContext, nonQuery, async () =>
+        {
+            var ids = await SelectTargetIdsAsync<TSource>(
+                queryContext, entityType, bsonSerializerFactory, nonQuery).ConfigureAwait(false);
+            if (ids.Count == 0)
+            {
+                return 0;
+            }
+
+            var update = TranslateBulkOrThrow(nonQuery,
+                () => BuildUpdate<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery));
+            return await UpdateByIdsAsync(queryContext, nonQuery, ids, update).ConfigureAwait(false);
+        });
+
+    private static int UpdateByIds(
+        QueryContext queryContext, MongoNonQueryExpression nonQuery, List<BsonValue> ids,
+        UpdateDefinition<BsonDocument> update)
+    {
+        var (collection, session) = GetBulkCollectionAndSession(queryContext, nonQuery);
+        var filter = Builders<BsonDocument>.Filter.In("_id", ids);
+
+        var updateLogger = GetUpdateLogger(queryContext);
+        var stopwatch = Stopwatch.StartNew();
+        updateLogger.ExecutingBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace, ids.Count);
+
+        var result = session == null
+            ? collection.UpdateMany(filter, update)
+            : collection.UpdateMany(session, filter, update);
+
+        updateLogger.ExecutedBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace, result.ModifiedCount);
+        return checked((int)result.MatchedCount);
+    }
+
+    private static async Task<int> UpdateByIdsAsync(
+        QueryContext queryContext, MongoNonQueryExpression nonQuery, List<BsonValue> ids,
+        UpdateDefinition<BsonDocument> update)
+    {
+        var (collection, session) = GetBulkCollectionAndSession(queryContext, nonQuery);
+        var filter = Builders<BsonDocument>.Filter.In("_id", ids);
+
+        var updateLogger = GetUpdateLogger(queryContext);
+        var stopwatch = Stopwatch.StartNew();
+        updateLogger.ExecutingBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace, ids.Count);
+
+        var cancellationToken = queryContext.CancellationToken;
+        var result = session == null
+            ? await collection.UpdateManyAsync(filter, update, options: null, cancellationToken).ConfigureAwait(false)
+            : await collection.UpdateManyAsync(session, filter, update, options: null, cancellationToken)
+                .ConfigureAwait(false);
+
+        updateLogger.ExecutedBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace, result.ModifiedCount);
+        return checked((int)result.MatchedCount);
+    }
+
+    private static int DeleteByIds(
+        QueryContext queryContext, MongoNonQueryExpression nonQuery, List<BsonValue> ids)
+    {
+        var (collection, session) = GetBulkCollectionAndSession(queryContext, nonQuery);
+        var filter = Builders<BsonDocument>.Filter.In("_id", ids);
+
+        var updateLogger = GetUpdateLogger(queryContext);
+        var stopwatch = Stopwatch.StartNew();
+        updateLogger.ExecutingBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace, ids.Count);
+
+        var result = session == null ? collection.DeleteMany(filter) : collection.DeleteMany(session, filter);
+
+        updateLogger.ExecutedBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace, result.DeletedCount);
+        return checked((int)result.DeletedCount);
+    }
+
+    private static async Task<int> DeleteByIdsAsync(
+        QueryContext queryContext, MongoNonQueryExpression nonQuery, List<BsonValue> ids)
+    {
+        var (collection, session) = GetBulkCollectionAndSession(queryContext, nonQuery);
+        var filter = Builders<BsonDocument>.Filter.In("_id", ids);
+
+        var updateLogger = GetUpdateLogger(queryContext);
+        var stopwatch = Stopwatch.StartNew();
+        updateLogger.ExecutingBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace, ids.Count);
+
+        var cancellationToken = queryContext.CancellationToken;
+        var result = session == null
+            ? await collection.DeleteManyAsync(filter, cancellationToken).ConfigureAwait(false)
+            : await collection.DeleteManyAsync(session, filter, options: null, cancellationToken).ConfigureAwait(false);
+
+        updateLogger.ExecutedBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace, result.DeletedCount);
+        return checked((int)result.DeletedCount);
+    }
+
+    private static (IMongoCollection<BsonDocument> collection, IClientSessionHandle? session) GetBulkCollectionAndSession(
+        QueryContext queryContext, MongoNonQueryExpression nonQuery)
+    {
+        var mongoQueryContext = (MongoQueryContext)queryContext;
+        var collection =
+            mongoQueryContext.MongoClient.GetCollection<BsonDocument>(nonQuery.SourceQuery.CollectionExpression.CollectionName);
+        var session = (mongoQueryContext.Context.Database.CurrentTransaction as MongoTransaction)?.Session;
+        return (collection, session);
+    }
+
+    private static int ExecuteDelete<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var (collection, session, filter) = PrepareBulk<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+
+        var updateLogger = GetUpdateLogger(queryContext);
+        var stopwatch = Stopwatch.StartNew();
+        updateLogger.ExecutingBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace);
+
+        var result = session == null
+            ? collection.DeleteMany(filter)
+            : collection.DeleteMany(session, filter);
+
+        updateLogger.ExecutedBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace, result.DeletedCount);
+
+        // DeletedCount is long; EF's ExecuteDelete contract returns int — overflow past int.MaxValue throws by design.
+        return checked((int)result.DeletedCount);
+    }
+
+    private static async Task<int> ExecuteDeleteAsync<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var (collection, session, filter) = PrepareBulk<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+
+        var updateLogger = GetUpdateLogger(queryContext);
+        var stopwatch = Stopwatch.StartNew();
+        updateLogger.ExecutingBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace);
+
+        var cancellationToken = queryContext.CancellationToken;
+        var result = session == null
+            ? await collection.DeleteManyAsync(filter, cancellationToken).ConfigureAwait(false)
+            : await collection.DeleteManyAsync(session, filter, options: null, cancellationToken).ConfigureAwait(false);
+
+        updateLogger.ExecutedBulkDelete(stopwatch.Elapsed, collection.CollectionNamespace, result.DeletedCount);
+
+        // DeletedCount is long; EF's ExecuteDelete contract returns int — overflow past int.MaxValue throws by design.
+        return checked((int)result.DeletedCount);
+    }
+
+    private static int ExecuteUpdate<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var (collection, session, filter) = PrepareBulk<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+        var update = TranslateBulkOrThrow(nonQuery, () => BuildUpdate<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery));
+
+        var updateLogger = GetUpdateLogger(queryContext);
+        var stopwatch = Stopwatch.StartNew();
+        updateLogger.ExecutingBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace);
+
+        var result = session == null
+            ? collection.UpdateMany(filter, update)
+            : collection.UpdateMany(session, filter, update);
+
+        updateLogger.ExecutedBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace, result.ModifiedCount);
+
+        // EF's ExecuteUpdate contract returns the number of rows matched by the predicate (the same as relational
+        // providers, which count a row even when SET writes its existing value), not just those whose stored
+        // values actually changed. MongoDB's UpdateResult exposes both; MatchedCount is the affected-row count.
+        // (The ExecutedBulkUpdate event above still reports ModifiedCount — the genuinely-modified subset.)
+        // MatchedCount is long; overflow past int.MaxValue throws by design.
+        return checked((int)result.MatchedCount);
+    }
+
+    private static async Task<int> ExecuteUpdateAsync<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var (collection, session, filter) = PrepareBulk<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+        var update = TranslateBulkOrThrow(nonQuery, () => BuildUpdate<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery));
+
+        var updateLogger = GetUpdateLogger(queryContext);
+        var stopwatch = Stopwatch.StartNew();
+        updateLogger.ExecutingBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace);
+
+        var cancellationToken = queryContext.CancellationToken;
+        var result = session == null
+            ? await collection.UpdateManyAsync(filter, update, options: null, cancellationToken).ConfigureAwait(false)
+            : await collection.UpdateManyAsync(session, filter, update, options: null, cancellationToken).ConfigureAwait(false);
+
+        updateLogger.ExecutedBulkUpdate(stopwatch.Elapsed, collection.CollectionNamespace, result.ModifiedCount);
+
+        // EF's ExecuteUpdate contract returns the number of rows matched by the predicate (the same as relational
+        // providers, which count a row even when SET writes its existing value), not just those whose stored
+        // values actually changed. MongoDB's UpdateResult exposes both; MatchedCount is the affected-row count.
+        // (The ExecutedBulkUpdate event above still reports ModifiedCount — the genuinely-modified subset.)
+        // MatchedCount is long; overflow past int.MaxValue throws by design.
+        return checked((int)result.MatchedCount);
+    }
+
+    // Server-side ExecuteDelete/ExecuteUpdate bypass SaveChanges, so the bulk-write logging in MongoDatabaseWrapper
+    // never fires for them. Resolve the Update-category logger from the context's service provider to emit the
+    // dedicated bulk delete/update events. IDiagnosticsLogger<> is registered as an open generic in EF Core's DI.
+    private static IDiagnosticsLogger<DbLoggerCategory.Update> GetUpdateLogger(QueryContext queryContext)
+        => queryContext.Context.GetService<IDiagnosticsLogger<DbLoggerCategory.Update>>();
+
+    // The bulk filter/update is translated from user expressions at execution time. When a predicate or
+    // setter shape that slipped past compile-time validation can't be translated (e.g. a GroupBy subquery
+    // in the Where), the driver/LINQ layer throws a raw ExpressionNotSupportedException / ArgumentException.
+    // Convert those into EF Core's canonical non-query translation failure so callers see a consistent
+    // "could not be translated" error. InvalidOperationException is left as-is — it already carries either
+    // that canonical message or the provider's cross-DbSet rejection.
+    private static T TranslateBulkOrThrow<T>(MongoNonQueryExpression nonQuery, Func<T> translate)
+    {
+        try
+        {
+            return translate();
+        }
+        catch (Exception exception) when (exception is not InvalidOperationException)
+        {
+            throw new InvalidOperationException(
+                CoreStrings.NonQueryTranslationFailedWithDetails(
+                    nonQuery.SourceQuery.CapturedExpression?.Print(),
+                    exception.Message),
+                exception);
+        }
+    }
+
+    private static (IMongoCollection<BsonDocument> collection, IClientSessionHandle? session, FilterDefinition<BsonDocument> filter) PrepareBulk<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var mongoQueryContext = (MongoQueryContext)queryContext;
+        var collection =
+            mongoQueryContext.MongoClient.GetCollection<BsonDocument>(nonQuery.SourceQuery.CollectionExpression.CollectionName);
+        var session = (mongoQueryContext.Context.Database.CurrentTransaction as MongoTransaction)?.Session;
+        var filter = TranslateBulkOrThrow(nonQuery, () => BuildFilter<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery));
+
+        return (collection, session, filter);
+    }
+
+    // Validates that the entity has a primary key mapped to _id (always true for a MongoDB root entity).
+    // Keyless entities cannot use two-phase delete and fall back to the canonical non-query failure.
+    private static void EnsureBulkKeyOrThrow(IReadOnlyEntityType entityType, MongoNonQueryExpression nonQuery)
+    {
+        if (entityType.FindPrimaryKey() == null)
+        {
+            throw new InvalidOperationException(
+                CoreStrings.NonQueryTranslationFailedWithDetails(
+                    nonQuery.SourceQuery.CapturedExpression?.Print(),
+                    "the entity must have a primary key to use ordering, paging, or Distinct in a bulk delete or update."));
+        }
+    }
+
+    // Phase 1: run the bulk source (Where + OrderBy/Skip/Take/Distinct) as a read that yields the raw stored
+    // BsonDocuments — reusing the read-path translation — and collect each document's _id. This works
+    // uniformly for scalar and composite primary keys (MongoDB stores a composite key as the _id sub-document)
+    // and never goes through EntitySerializer's (unimplemented) round-trip serialization.
+    private static List<BsonValue> SelectTargetIds<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var documents = BuildIdDocumentQuery<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+
+        var ids = new List<BsonValue>();
+        foreach (var document in documents)
+        {
+            ids.Add(document["_id"]);
+        }
+
+        return ids;
+    }
+
+    private static async Task<List<BsonValue>> SelectTargetIdsAsync<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var documents = BuildIdDocumentQuery<TSource>(queryContext, entityType, bsonSerializerFactory, nonQuery);
+
+        var materialized = await IAsyncCursorSourceExtensions
+            .ToListAsync((IAsyncCursorSource<BsonDocument>)documents, queryContext.CancellationToken).ConfigureAwait(false);
+
+        var ids = new List<BsonValue>(materialized.Count);
+        foreach (var document in materialized)
+        {
+            ids.Add(document["_id"]);
+        }
+
+        return ids;
+    }
+
+    // Builds a driver query that yields the raw stored BsonDocuments for the bulk source, by reusing the
+    // read path's TranslateQuery (which applies Where/OrderBy/Skip/Take/Distinct via the driver and reads the
+    // ambient transaction session) and asking the driver provider for BsonDocument results.
+    // Note: this fetches whole documents and keeps only _id; a future optimization could push a
+    // { _id: 1 } projection server-side to reduce transfer for large target sets.
+    private static IQueryable<BsonDocument> BuildIdDocumentQuery<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var (_, executableQuery) = TranslateQuery<TSource>(
+            queryContext, entityType, bsonSerializerFactory, nonQuery.SourceQuery, ResultCardinality.Enumerable,
+            (translator, expression) =>
+                translator.Translate(MongoNonQueryExpression.UnwrapBulkOperator(expression)!, ResultCardinality.Enumerable));
+
+        return executableQuery.Provider.CreateQuery<BsonDocument>(executableQuery.Query);
+    }
+
+    /// <summary>
+    /// Builds the server-side <see cref="FilterDefinition{BsonDocument}"/> that scopes a bulk operation by combining the
+    /// predicates of every <c>Where</c> in the captured chain. Each predicate body is lowered through the EF→driver-LINQ
+    /// visitor (rewriting <c>EF.Property</c> to <c>Mql.Field</c>) and rebound to a single shared parameter, then rendered
+    /// with the EF entity serializer so element names honor the EF model. An empty chain matches every document.
+    /// </summary>
+    private static FilterDefinition<BsonDocument> BuildFilter<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var sharedParameter = Expression.Parameter(typeof(TSource), "e");
+        var translator = new MongoEFToLinqTranslatingExpressionVisitor(
+            queryContext, Expression.Constant(null, typeof(IQueryable<TSource>)), bsonSerializerFactory);
+
+        Expression? combinedBody = null;
+        var expression = MongoNonQueryExpression.UnwrapBulkOperator(nonQuery.SourceQuery.CapturedExpression);
+        // Invariant: ValidateBulkSource (in the method-translating visitor) has already rejected any operator other than
+        // Queryable.Where, so this walk is exhaustive — a non-Where node here would be silently dropped.
+        while (expression is MethodCallExpression { Method: { DeclaringType: var declaringType, Name: nameof(Queryable.Where) } }
+                   whereCall
+               && declaringType == typeof(Queryable))
+        {
+            var predicate = whereCall.Arguments[1].UnwrapLambdaFromQuote();
+            var translatedBody = translator.Visit(predicate.Body)!;
+            translatedBody = ReplacingExpressionVisitor.Replace(predicate.Parameters[0], sharedParameter, translatedBody);
+
+            combinedBody = combinedBody == null ? translatedBody : Expression.AndAlso(combinedBody, translatedBody);
+
+            expression = whereCall.Arguments[0];
+        }
+
+        if (combinedBody == null)
+        {
+            return FilterDefinition<BsonDocument>.Empty;
+        }
+
+        var predicateLambda = Expression.Lambda<Func<TSource, bool>>(combinedBody, sharedParameter);
+        var efSerializer = (IBsonSerializer<TSource>)bsonSerializerFactory.GetEntitySerializer(entityType);
+        var rendered = new ExpressionFilterDefinition<TSource>(predicateLambda)
+            .Render(new RenderArgs<TSource>(efSerializer, BsonSerializer.SerializerRegistry));
+
+        return rendered;
+    }
+
+    /// <summary>
+    /// Builds the server-side update for a bulk update. When no setter is self-referencing the update is a simple
+    /// <c>$set</c> document of serialized literal values. When any setter references the entity being updated the update
+    /// becomes an aggregation pipeline containing a single <c>$set</c> stage; self-referencing setters contribute a
+    /// rendered aggregation expression and constant setters contribute their serialized literal (the two can mix freely).
+    /// </summary>
+    private static UpdateDefinition<BsonDocument> BuildUpdate<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoNonQueryExpression nonQuery)
+    {
+        var setters = nonQuery.Setters;
+
+        if (!setters.Any(s => s.IsSelfReferencing))
+        {
+            var setDoc = new BsonDocument();
+            foreach (var setter in setters)
+            {
+                setDoc[setter.Property.GetElementName()] = SerializeConstant(queryContext, setter);
+            }
+
+            return new BsonDocumentUpdateDefinition<BsonDocument>(new BsonDocument("$set", setDoc));
+        }
+
+        // Pipeline-form update: required as soon as any setter references the document being updated.
+        var efSerializer = (IBsonSerializer<TSource>)bsonSerializerFactory.GetEntitySerializer(entityType);
+        var entityParameter = Expression.Parameter(typeof(TSource), "e");
+        var setStageDoc = new BsonDocument();
+
+        foreach (var setter in setters)
+        {
+            if (setter.IsSelfReferencing)
+            {
+                setStageDoc[setter.Property.GetElementName()] = RenderSelfReferencingValue<TSource>(
+                    queryContext, bsonSerializerFactory, entityParameter, efSerializer, setter);
+            }
+            else
+            {
+                setStageDoc[setter.Property.GetElementName()] = SerializeConstant(queryContext, setter);
+            }
+        }
+
+        var setStage = new BsonDocument("$set", setStageDoc);
+        var pipeline = PipelineDefinition<BsonDocument, BsonDocument>.Create(new[] { setStage });
+        return Builders<BsonDocument>.Update.Pipeline(pipeline);
+    }
+
+    /// <summary>
+    /// Evaluates a constant/parameter setter value to a CLR constant and serializes it to a <see cref="BsonValue"/>
+    /// using the same property serializer the write pipeline uses, so enum / Guid / representation handling matches
+    /// inserts and SaveChanges updates.
+    /// </summary>
+    private static BsonValue SerializeConstant(QueryContext queryContext, MongoNonQueryExpression.Setter setter)
+    {
+        var value = EvaluateToConstant(queryContext, setter.ValueExpression);
+        var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(setter.Property);
+        return serializationInfo.SerializeValue(value);
+    }
+
+    /// <summary>
+    /// Renders a self-referencing setter value (e.g. <c>o =&gt; o.Quantity + 1</c>) to an aggregation-expression
+    /// <see cref="BsonValue"/>. The value body is lowered through the EF→driver-LINQ visitor, rebound to a single shared
+    /// parameter, and rendered with the EF entity serializer so element names honor the EF model.
+    /// </summary>
+    private static BsonValue RenderSelfReferencingValue<TSource>(
+        QueryContext queryContext,
+        BsonSerializerFactory bsonSerializerFactory,
+        ParameterExpression entityParameter,
+        IBsonSerializer<TSource> efSerializer,
+        MongoNonQueryExpression.Setter setter)
+    {
+        var translator = new MongoEFToLinqTranslatingExpressionVisitor(
+            queryContext, Expression.Constant(null, typeof(IQueryable<TSource>)), bsonSerializerFactory);
+        var translatedBody = translator.Visit(setter.ValueExpression)!;
+
+        // The translated body still references the original setter parameter(s); rebind to the shared parameter.
+        translatedBody = new ParameterRebindingExpressionVisitor(entityParameter).Visit(translatedBody);
+
+        var resultType = setter.Property.ClrType;
+        var renderer = RenderAggregateExpressionMethodInfo.MakeGenericMethod(typeof(TSource), resultType);
+        return (BsonValue)renderer.Invoke(null, [entityParameter, translatedBody, efSerializer])!;
+    }
+
+    private static BsonValue RenderAggregateExpression<TSource, TResult>(
+        ParameterExpression entityParameter,
+        Expression body,
+        IBsonSerializer<TSource> efSerializer)
+    {
+        var lambda = Expression.Lambda<Func<TSource, TResult>>(
+            body.Type == typeof(TResult) ? body : Expression.Convert(body, typeof(TResult)),
+            entityParameter);
+        return new ExpressionAggregateExpressionDefinition<TSource, TResult>(lambda)
+            .Render(new RenderArgs<TSource>(efSerializer, BsonSerializer.SerializerRegistry));
+    }
+
+    /// <summary>
+    /// Evaluates a setter value expression (constant, captured closure, or query parameter) to a CLR value.
+    /// Unlike <c>MongoEFToLinqTranslatingExpressionVisitor.TryEvaluateToConstant</c>, this method intentionally
+    /// lets compile-and-evaluate failures propagate as exceptions — throwing on an un-evaluatable setter value
+    /// is preferable to silently writing null.
+    /// </summary>
+    private static object? EvaluateToConstant(QueryContext queryContext, Expression expression)
+    {
+        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } convert)
+        {
+            expression = convert.Operand;
+        }
+
+        if (expression is ConstantExpression constant)
+        {
+            return constant.Value;
+        }
+
+        if (expression is MemberExpression { Expression: ConstantExpression closureConstant } member)
+        {
+            return member.Member switch
+            {
+                FieldInfo field => field.GetValue(closureConstant.Value),
+                PropertyInfo prop => prop.GetValue(closureConstant.Value),
+                _ => CompileAndEvaluate(expression)
+            };
+        }
+
+#if EF8 || EF9
+        if (expression is ParameterExpression param
+            && param.Name?.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal) == true
+            && queryContext.ParameterValues.TryGetValue(param.Name, out var value))
+        {
+            return value;
+        }
+#else
+        if (expression is Microsoft.EntityFrameworkCore.Query.QueryParameterExpression queryParam)
+        {
+            return queryContext.Parameters[queryParam.Name];
+        }
+#endif
+
+        return CompileAndEvaluate(expression);
+    }
+
+    private static object? CompileAndEvaluate(Expression expression)
+        => Expression.Lambda<Func<object?>>(Expression.Convert(expression, typeof(object))).Compile()();
+
+    /// <summary>
+    /// Rebinds every <see cref="ParameterExpression"/> in a translated self-referencing setter body to a single shared
+    /// parameter, so the assembled value lambda has exactly one parameter as required by the renderer.
+    /// </summary>
+    private sealed class ParameterRebindingExpressionVisitor(ParameterExpression target)
+        : System.Linq.Expressions.ExpressionVisitor
+    {
+        protected override Expression VisitParameter(ParameterExpression node)
+            // Rebind by type rather than by identity: translation through MongoEFToLinqTranslatingExpressionVisitor
+            // discards the original parameter identity, and the value body has exactly one TSource-typed parameter
+            // (the setter's own), so type-based rebinding is safe for the supported single-setter value shapes.
+            => node.Type == target.Type ? target : base.VisitParameter(node);
+    }
+
+    private static readonly MethodInfo ExecuteDeleteMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(ExecuteDelete));
+
+    private static readonly MethodInfo ExecuteDeleteAsyncMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(ExecuteDeleteAsync));
+
+    private static readonly MethodInfo ExecuteUpdateMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(ExecuteUpdate));
+
+    private static readonly MethodInfo ExecuteUpdateAsyncMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(ExecuteUpdateAsync));
+
+    private static readonly MethodInfo ExecuteTwoPhaseDeleteMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(ExecuteTwoPhaseDelete));
+
+    private static readonly MethodInfo ExecuteTwoPhaseDeleteAsyncMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(ExecuteTwoPhaseDeleteAsync));
+
+    private static readonly MethodInfo ExecuteTwoPhaseUpdateMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(ExecuteTwoPhaseUpdate));
+
+    private static readonly MethodInfo ExecuteTwoPhaseUpdateAsyncMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(ExecuteTwoPhaseUpdateAsync));
+
+    private static readonly MethodInfo RenderAggregateExpressionMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(RenderAggregateExpression));
+#endif
 
     private static readonly MethodInfo ExecuteShapedQueryMethodInfo =
         typeof(MongoShapedQueryCompilingExpressionVisitor)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/BulkOperationsUnsupportedOnEf8Tests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/BulkOperationsUnsupportedOnEf8Tests.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2023-present MongoDB Inc.
+/* Copyright 2023-present MongoDB Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,38 +13,36 @@
  * limitations under the License.
  */
 
-using System.Linq.Expressions;
-using System.Reflection;
+// On EF8 the provider does not implement ExecuteDelete/ExecuteUpdate (the whole bulk path is #if !EF8),
+// so EF Core reports the operation as untranslatable. This pins that clean-failure boundary. On EF9+ the
+// feature is implemented and exercised by ExecuteDeleteTests / ExecuteUpdateTests instead.
+#if EF8
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
+using Xunit;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 
 [XUnitCollection("QueryTests")]
-public class InvalidQueryTranslationTests(TemporaryDatabaseFixture database)
+public class BulkOperationsUnsupportedOnEf8Tests(TemporaryDatabaseFixture database)
     : IClassFixture<TemporaryDatabaseFixture>
 {
-    class SimpleEntity
+    private class SimpleEntity
     {
-        public Guid _id { get; set; }
-        public string name { get; set; }
+        public ObjectId _id { get; set; }
     }
 
     [Fact]
-    public void ExecuteDelete_throws_invalid_operation_exception()
+    public void ExecuteDelete_throws_translation_failure()
     {
         using var db = SingleEntityDbContext.Create(database.CreateCollection<SimpleEntity>());
 
         var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.ExecuteDelete());
-        Assert.Contains("ExecuteDelete", ex.Message);
-        Assert.Contains("LINQ expression", ex.Message);
+        Assert.Contains("could not be translated", ex.Message);
     }
 }
 
-static class FakeQueryableExtensions
-{
-    internal static int ExecuteDelete<TSource>(this IQueryable<TSource> source)
-        => source.Provider.Execute<int>(Expression.Call(ExecuteDeleteMethodInfo.MakeGenericMethod(typeof(TSource)),
-            source.Expression));
-
-    private static readonly MethodInfo ExecuteDeleteMethodInfo
-        = typeof(FakeQueryableExtensions).GetTypeInfo().GetDeclaredMethod(nameof(ExecuteDelete))!;
-}
+#endif

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteDeleteTests.cs
@@ -1,0 +1,350 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if !EF8
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Diagnostics;
+using Xunit;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+public class ExecuteDeleteTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    private class Order
+    {
+        public ObjectId _id { get; set; }
+        public string Status { get; set; } = null!; // mapped to "state" via HasElementName
+        public int Quantity { get; set; }
+    }
+
+    private static readonly Action<ModelBuilder> ConfigureModel = mb =>
+    {
+        mb.Entity<Order>().Property(e => e.Status).HasElementName("state");
+    };
+
+    private SingleEntityDbContext<Order> CreateSeededContext([CallerMemberName] string? collectionName = null)
+    {
+        var collection = database.CreateCollection<Order>(collectionName);
+
+        using (var seedDb = SingleEntityDbContext.Create(collection, ConfigureModel))
+        {
+            seedDb.AddRange(
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 10 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 20 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "closed", Quantity = 30 });
+            seedDb.SaveChanges();
+        }
+
+        return SingleEntityDbContext.Create(collection, ConfigureModel);
+    }
+
+    [Fact]
+    public void ExecuteDelete_with_predicate_deletes_matching_and_returns_count()
+    {
+        using var db = CreateSeededContext();
+
+        var deleted = db.Entities.Where(o => o.Status == "open").ExecuteDelete();
+
+        Assert.Equal(2, deleted);
+        Assert.Equal(1, db.Entities.Count());
+        Assert.Equal("closed", db.Entities.Single().Status);
+    }
+
+    [Fact]
+    public async Task ExecuteDeleteAsync_with_predicate_deletes_matching_and_returns_count()
+    {
+        using var db = CreateSeededContext();
+
+        var deleted = await db.Entities.Where(o => o.Quantity >= 20).ExecuteDeleteAsync();
+
+        Assert.Equal(2, deleted);
+        Assert.Equal(1, db.Entities.Count());
+        Assert.Equal(10, db.Entities.Single().Quantity);
+    }
+
+    [Fact]
+    public void ExecuteDelete_without_predicate_deletes_everything()
+    {
+        using var db = CreateSeededContext();
+
+        var deleted = db.Entities.ExecuteDelete();
+
+        Assert.Equal(3, deleted);
+        Assert.Equal(0, db.Entities.Count());
+    }
+
+    [Fact]
+    public void ExecuteDelete_with_OrderBy_and_no_Take_deletes_everything()
+    {
+        // OrderBy alone (without Skip/Take) triggers the two-phase path but deletes all documents —
+        // semantically equivalent to the single-command path.
+        using var db = CreateSeededContext();
+
+        var deleted = db.Entities.OrderBy(o => o.Quantity).ExecuteDelete();
+
+        Assert.Equal(3, deleted);
+        Assert.Equal(0, db.Entities.Count());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteDelete_logs_ExecutedBulkDelete_event_with_count(bool async)
+    {
+        var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
+        var collection = database.CreateCollection<Order>(nameof(ExecuteDelete_logs_ExecutedBulkDelete_event_with_count), async);
+
+        using (var seedDb = SingleEntityDbContext.Create(collection, ConfigureModel))
+        {
+            seedDb.AddRange(
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 10 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 20 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "closed", Quantity = 30 });
+            seedDb.SaveChanges();
+        }
+
+        using var db = SingleEntityDbContext.Create(collection, loggerFactory, ConfigureModel);
+
+        var deleted = async
+            ? await db.Entities.Where(o => o.Status == "open").ExecuteDeleteAsync()
+            : db.Entities.Where(o => o.Status == "open").ExecuteDelete();
+
+        Assert.Equal(2, deleted);
+
+        var executingMessage = spyLogger.GetLogMessageByEventId(MongoEventId.ExecutingBulkDelete);
+        Assert.Contains("Executing Bulk Delete", executingMessage);
+        Assert.Contains($"Collection='{collection.CollectionNamespace}'", executingMessage);
+
+        var executedMessage = spyLogger.GetLogMessageByEventId(MongoEventId.ExecutedBulkDelete);
+        Assert.Contains("Executed Bulk Delete", executedMessage);
+        Assert.Contains($"Collection='{collection.CollectionNamespace}'", executedMessage);
+        Assert.Contains("Deleted=2", executedMessage);
+    }
+
+    [Fact]
+    public void ExecuteDelete_with_two_Where_clauses_deletes_matching_both_and_returns_count()
+    {
+        using var db = CreateSeededContext();
+
+        var deleted = db.Entities
+            .Where(o => o.Status == "open")
+            .Where(o => o.Quantity >= 20)
+            .ExecuteDelete();
+
+        Assert.Equal(1, deleted);
+        Assert.Equal(2, db.Entities.Count());
+        Assert.DoesNotContain(db.Entities.ToList(), o => o.Status == "open" && o.Quantity >= 20);
+    }
+
+    [Fact]
+    public void ExecuteDelete_with_OrderBy_Take_deletes_lowest_quantities()
+    {
+        using var db = CreateSeededContext();
+
+        var deleted = db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDelete();
+
+        Assert.Equal(2, deleted);
+        var remaining = db.Entities.OrderBy(o => o.Quantity).ToList();
+        Assert.Single(remaining);
+        Assert.Equal(30, remaining[0].Quantity);
+    }
+
+    [Fact]
+    public void ExecuteDelete_with_Where_and_Skip_Take_scopes_to_window()
+    {
+        using var db = CreateSeededContext();
+
+        var deleted = db.Entities.Where(o => o.Status == "open").OrderBy(o => o.Quantity).Skip(1).Take(1).ExecuteDelete();
+
+        Assert.Equal(1, deleted);
+        Assert.Equal(2, db.Entities.Count());
+        Assert.DoesNotContain(db.Entities.ToList(), o => o.Quantity == 20);
+    }
+
+    [Fact]
+    public void ExecuteDelete_two_phase_empty_target_returns_zero()
+    {
+        using var db = CreateSeededContext();
+
+        var deleted = db.Entities.Where(o => o.Status == "nonexistent").OrderBy(o => o.Quantity).Take(5).ExecuteDelete();
+
+        Assert.Equal(0, deleted);
+        Assert.Equal(3, db.Entities.Count());
+    }
+
+    [Fact]
+    public void ExecuteDelete_two_phase_rolls_back_inside_user_transaction()
+    {
+        using var db = CreateSeededContext();
+        using (var tx = db.Database.BeginTransaction())
+        {
+            var deleted = db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDelete();
+            Assert.Equal(2, deleted);
+            tx.Rollback();
+        }
+
+        Assert.Equal(3, db.Entities.Count());
+    }
+
+    [Fact]
+    public void ExecuteDelete_two_phase_with_AutoTransactionBehavior_Never_throws_and_changes_nothing()
+    {
+        using var db = CreateSeededContext();
+        db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDelete());
+
+        Assert.Contains("AutoTransactionBehavior", ex.Message);
+        Assert.Equal(3, db.Entities.Count()); // nothing deleted
+    }
+
+    [Fact]
+    public void ExecuteDelete_single_command_with_AutoTransactionBehavior_Never_still_works()
+    {
+        using var db = CreateSeededContext();
+        db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+
+        // Where-only path is single-command and needs no transaction — Never must not affect it.
+        var deleted = db.Entities.Where(o => o.Status == "open").ExecuteDelete();
+
+        Assert.Equal(2, deleted);
+    }
+
+    [Fact]
+    public void ExecuteDelete_with_Distinct_deletes_matching()
+    {
+        // Distinct on a root entity triggers the two-phase execution path: phase 1 reads the
+        // distinct matching _ids, phase 2 deletes by { _id: { $in: [...] } }.
+        using var db = CreateSeededContext();
+
+        var deleted = db.Entities.Where(o => o.Status == "open").Distinct().ExecuteDelete();
+
+        Assert.Equal(2, deleted);
+        Assert.Equal(1, db.Entities.Count());
+        Assert.Equal("closed", db.Entities.Single().Status);
+    }
+
+    [Fact(Skip = "Requires a standalone (non-replica-set) MongoDB to exercise the transaction-unsupported path; "
+        + "CI/local use a replica set (atlas-local). The error mapping is covered by IsTransactionsUnsupported. EF-107")]
+    public void ExecuteDelete_two_phase_on_standalone_throws_actionable_error()
+    {
+        // Intentionally skipped — see Skip reason.
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteDelete_two_phase_logs_ExecutingBulkDelete_with_target_count(bool async)
+    {
+        var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
+        var collection = database.CreateCollection<Order>(
+            nameof(ExecuteDelete_two_phase_logs_ExecutingBulkDelete_with_target_count), async);
+
+        using (var seedDb = SingleEntityDbContext.Create(collection, ConfigureModel))
+        {
+            seedDb.AddRange(
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 10 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 20 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "closed", Quantity = 30 });
+            seedDb.SaveChanges();
+        }
+
+        using var db = SingleEntityDbContext.Create(collection, loggerFactory, ConfigureModel);
+
+        // Two-phase path: OrderBy + Take triggers phase-1 id selection then phase-2 DeleteByIds.
+        var deleted = async
+            ? await db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDeleteAsync()
+            : db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDelete();
+
+        Assert.Equal(2, deleted);
+
+        var executingMessage = spyLogger.GetLogMessageByEventId(MongoEventId.ExecutingBulkDelete);
+        Assert.Contains("Executing Bulk Delete", executingMessage);
+        Assert.Contains($"Collection='{collection.CollectionNamespace}'", executingMessage);
+        Assert.Contains("two-phase", executingMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("2 target(s)", executingMessage);
+    }
+
+    [Fact]
+    public void ExecuteDelete_two_phase_commits_inside_user_transaction()
+    {
+        using var db = CreateSeededContext();
+        using (var tx = db.Database.BeginTransaction())
+        {
+            // Two-phase runs on the ambient session; the provider must NOT commit the user's transaction.
+            var deleted = db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDelete();
+            Assert.Equal(2, deleted);
+            tx.Commit();
+        }
+
+        // Committed by the user: the two-phase delete persisted.
+        Assert.Equal(1, db.Entities.Count());
+        Assert.Equal(30, db.Entities.Single().Quantity);
+    }
+
+    private class LineItem
+    {
+        public int OrderId { get; set; }
+        public int ProductId { get; set; }
+        public string Status { get; set; } = null!;
+        public int Quantity { get; set; }
+    }
+
+    private static readonly Action<ModelBuilder> ConfigureCompositeKeyModel = mb =>
+    {
+        // Composite primary key maps to a composite _id sub-document in MongoDB.
+        mb.Entity<LineItem>().HasKey(e => new { e.OrderId, e.ProductId });
+    };
+
+    private SingleEntityDbContext<LineItem> CreateSeededCompositeKeyContext([CallerMemberName] string? collectionName = null)
+    {
+        var collection = database.CreateCollection<LineItem>(collectionName);
+
+        using (var seedDb = SingleEntityDbContext.Create(collection, ConfigureCompositeKeyModel))
+        {
+            seedDb.AddRange(
+                new LineItem { OrderId = 1, ProductId = 1, Status = "open", Quantity = 10 },
+                new LineItem { OrderId = 1, ProductId = 2, Status = "open", Quantity = 20 },
+                new LineItem { OrderId = 2, ProductId = 1, Status = "closed", Quantity = 30 });
+            seedDb.SaveChanges();
+        }
+
+        return SingleEntityDbContext.Create(collection, ConfigureCompositeKeyModel);
+    }
+
+    [Fact]
+    public void ExecuteDelete_two_phase_with_composite_key_deletes_targeted_rows()
+    {
+        using var db = CreateSeededCompositeKeyContext();
+
+        // Two-phase on a composite-key entity: phase 1 must collect composite _id sub-documents,
+        // phase 2 deletes by { _id: { $in: [ { OrderId, ProductId }, ... ] } }.
+        var deleted = db.Entities.OrderBy(o => o.Quantity).Take(2).ExecuteDelete();
+
+        Assert.Equal(2, deleted);
+        var remaining = db.Entities.Single();
+        Assert.Equal(30, remaining.Quantity);
+    }
+}
+
+#endif

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ExecuteUpdateTests.cs
@@ -1,0 +1,428 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if !EF8
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Diagnostics;
+using Xunit;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+public class ExecuteUpdateTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    private class Order
+    {
+        public ObjectId _id { get; set; }
+        public string Status { get; set; } = null!; // mapped to "state" via HasElementName
+        public int Quantity { get; set; }
+        [NotMapped] public string Unmapped { get; set; } = null!;
+    }
+
+    private class OrderWithConverter
+    {
+        public ObjectId _id { get; set; }
+        public int Quantity { get; set; } // stored as string via HasConversion
+    }
+
+    private static readonly Action<ModelBuilder> ConfigureConverterModel = mb =>
+    {
+        mb.Entity<OrderWithConverter>().Property(e => e.Quantity).HasConversion<string>();
+    };
+
+    private static readonly Action<ModelBuilder> ConfigureModel = mb =>
+    {
+        mb.Entity<Order>().Property(e => e.Status).HasElementName("state");
+    };
+
+    private SingleEntityDbContext<Order> CreateSeededContext([CallerMemberName] string? collectionName = null)
+    {
+        var collection = database.CreateCollection<Order>(collectionName);
+
+        using (var seedDb = SingleEntityDbContext.Create(collection, ConfigureModel))
+        {
+            seedDb.AddRange(
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 10 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 20 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "closed", Quantity = 30 });
+            seedDb.SaveChanges();
+        }
+
+        return SingleEntityDbContext.Create(collection, ConfigureModel);
+    }
+
+    [Fact]
+    public void ExecuteUpdate_constant_set_updates_matching_and_returns_count()
+    {
+        using var db = CreateSeededContext();
+
+        var updated = db.Entities
+            .Where(o => o.Status == "open")
+            .ExecuteUpdate(s => s.SetProperty(o => o.Status, "shipped"));
+
+        Assert.Equal(2, updated);
+        Assert.Equal(2, db.Entities.Count(o => o.Status == "shipped"));
+        Assert.Equal(1, db.Entities.Count(o => o.Status == "closed"));
+    }
+
+    [Fact]
+    public void ExecuteUpdate_returns_matched_count_even_when_values_already_match()
+    {
+        using var db = CreateSeededContext();
+
+        // Both matched docs already have Status "open", so the server reports ModifiedCount 0;
+        // ExecuteUpdate must still return the matched-row count (2), matching EF Core's contract
+        // (relational providers count a row even when SET writes its existing value).
+        var updated = db.Entities
+            .Where(o => o.Status == "open")
+            .ExecuteUpdate(s => s.SetProperty(o => o.Status, "open"));
+
+        Assert.Equal(2, updated);
+    }
+
+    [Fact]
+    public void ExecuteUpdate_with_ef_property_setter_updates_matching()
+    {
+        using var db = CreateSeededContext();
+
+        // The setter target is EF.Property<string>(o, "Status") rather than a direct member access.
+        var updated = db.Entities
+            .Where(o => o.Status == "open")
+            .ExecuteUpdate(s => s.SetProperty(o => EF.Property<string>(o, nameof(Order.Status)), "shipped"));
+
+        Assert.Equal(2, updated);
+        Assert.Equal(2, db.Entities.Count(o => o.Status == "shipped"));
+    }
+
+    [Fact]
+    public void ExecuteUpdate_with_captured_variable_set_value()
+    {
+        using var db = CreateSeededContext();
+
+        var newStatus = "processing";
+        var updated = db.Entities
+            .Where(o => o.Quantity >= 20)
+            .ExecuteUpdate(s => s.SetProperty(o => o.Status, newStatus));
+
+        Assert.Equal(2, updated);
+        Assert.Equal(2, db.Entities.Count(o => o.Status == "processing"));
+    }
+
+    [Fact]
+    public void ExecuteUpdate_self_referencing_increments_matched_docs()
+    {
+        using var db = CreateSeededContext();
+
+        var updated = db.Entities
+            .Where(o => o.Status == "open")
+            .ExecuteUpdate(s => s.SetProperty(o => o.Quantity, o => o.Quantity + 1));
+
+        Assert.Equal(2, updated);
+        var quantities = db.Entities.OrderBy(o => o.Quantity).Select(o => o.Quantity).ToList();
+        // open: 10 -> 11, 20 -> 21; closed unchanged: 30
+        Assert.Equal(new[] { 11, 21, 30 }, quantities);
+    }
+
+    [Fact]
+    public async Task ExecuteUpdateAsync_self_referencing_increments_matched_docs()
+    {
+        using var db = CreateSeededContext();
+
+        var updated = await db.Entities
+            .Where(o => o.Quantity >= 20)
+            .ExecuteUpdateAsync(s => s.SetProperty(o => o.Quantity, o => o.Quantity * 2));
+
+        Assert.Equal(2, updated);
+        var quantities = db.Entities.OrderBy(o => o.Quantity).Select(o => o.Quantity).ToList();
+        // 10 unchanged; 20 -> 40; 30 -> 60
+        Assert.Equal(new[] { 10, 40, 60 }, quantities);
+    }
+
+    [Fact]
+    public void ExecuteUpdate_mixed_constant_and_self_referencing_in_one_call()
+    {
+        using var db = CreateSeededContext();
+
+        var updated = db.Entities
+            .Where(o => o.Status == "open")
+            .ExecuteUpdate(s => s
+                .SetProperty(o => o.Status, "bumped")
+                .SetProperty(o => o.Quantity, o => o.Quantity + 5));
+
+        Assert.Equal(2, updated);
+        var bumped = db.Entities.Where(o => o.Status == "bumped").OrderBy(o => o.Quantity).Select(o => o.Quantity).ToList();
+        Assert.Equal(new[] { 15, 25 }, bumped);
+        Assert.Equal(1, db.Entities.Count(o => o.Status == "closed"));
+    }
+
+    [Fact]
+    public void ExecuteUpdate_without_predicate_updates_everything()
+    {
+        using var db = CreateSeededContext();
+
+        var updated = db.Entities.ExecuteUpdate(s => s.SetProperty(o => o.Status, "all"));
+
+        Assert.Equal(3, updated);
+        Assert.Equal(3, db.Entities.Count(o => o.Status == "all"));
+    }
+
+    [Fact]
+    public void ExecuteUpdate_with_OrderBy_Take_updates_only_targeted_rows()
+    {
+        using var db = CreateSeededContext();
+
+        // Two-phase: phase 1 reads the top-2 _ids (ordered by Quantity), phase 2 applies the update.
+        var updated = db.Entities.OrderBy(o => o.Quantity).Take(2)
+            .ExecuteUpdate(s => s.SetProperty(o => o.Status, "archived"));
+
+        Assert.Equal(2, updated);
+        Assert.Equal(2, db.Entities.Count(o => o.Status == "archived"));
+        // The highest-quantity row must be untouched.
+        Assert.Equal(1, db.Entities.Count(o => o.Status == "closed"));
+    }
+
+    [Fact]
+    public void ExecuteUpdate_two_phase_self_referencing_setter()
+    {
+        using var db = CreateSeededContext();
+
+        // Two-phase: targets the single lowest-quantity document and increments its Quantity by 5.
+        var updated = db.Entities.OrderBy(o => o.Quantity).Take(1)
+            .ExecuteUpdate(s => s.SetProperty(o => o.Quantity, o => o.Quantity + 5));
+
+        Assert.Equal(1, updated);
+        // Lowest seeded Quantity is 10; +5 = 15.
+        Assert.Contains(db.Entities.ToList(), o => o.Quantity == 15);
+    }
+
+    [Fact]
+    public void ExecuteUpdate_two_phase_rolls_back_inside_user_transaction()
+    {
+        using var db = CreateSeededContext();
+
+        using (var tx = db.Database.BeginTransaction())
+        {
+            db.Entities.OrderBy(o => o.Quantity).Take(2)
+                .ExecuteUpdate(s => s.SetProperty(o => o.Status, "archived"));
+            tx.Rollback();
+        }
+
+        Assert.Equal(0, db.Entities.Count(o => o.Status == "archived"));
+    }
+
+    [Fact]
+    public void ExecuteUpdate_two_phase_with_AutoTransactionBehavior_Never_throws_and_changes_nothing()
+    {
+        using var db = CreateSeededContext();
+        db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => db.Entities.OrderBy(o => o.Quantity).Take(2)
+                .ExecuteUpdate(s => s.SetProperty(o => o.Status, "archived")));
+
+        Assert.Contains("AutoTransactionBehavior", ex.Message);
+        Assert.Equal(0, db.Entities.Count(o => o.Status == "archived")); // nothing updated
+    }
+
+#if EF9
+    // EF10 changed the setter parameter to an Action and validates "at least one SetProperty" upstream,
+    // so the empty-setter guard only applies to the EF9 translation path (where the raw lambda reaches us).
+    [Fact]
+    public void ExecuteUpdate_with_no_set_property_throws()
+    {
+        using var db = CreateSeededContext();
+
+        // A setter lambda with no SetProperty call must be rejected, not run as a no-op updateMany.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => db.Entities.ExecuteUpdate(s => s));
+        Assert.Contains("SetProperty", ex.Message);
+    }
+#endif
+
+    [Fact]
+    public void ExecuteUpdate_targeting_unmapped_property_throws()
+    {
+        using var db = CreateSeededContext();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => db.Entities.ExecuteUpdate(s => s.SetProperty(o => o.Unmapped, "x")));
+        Assert.Contains("Only mapped root scalar properties can be updated", ex.Message);
+    }
+
+    [Fact]
+    public void ExecuteUpdate_self_referencing_value_converter_property_throws()
+    {
+        var collection = database.CreateCollection<OrderWithConverter>();
+        using var db = SingleEntityDbContext.Create(collection, ConfigureConverterModel);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => db.Entities.ExecuteUpdate(s => s.SetProperty(o => o.Quantity, o => o.Quantity + 1)));
+        Assert.Contains("Self-referencing ExecuteUpdate on property", ex.Message);
+        Assert.Contains("value converter", ex.Message);
+    }
+
+    [Fact]
+    public void ExecuteUpdate_constant_set_on_value_converter_property_persists_converted_shape()
+    {
+        var collection = database.CreateCollection<OrderWithConverter>();
+        using (var seedDb = SingleEntityDbContext.Create(collection, ConfigureConverterModel))
+        {
+            seedDb.AddRange(
+                new OrderWithConverter { _id = ObjectId.GenerateNewId(), Quantity = 1 },
+                new OrderWithConverter { _id = ObjectId.GenerateNewId(), Quantity = 2 });
+            seedDb.SaveChanges();
+        }
+
+        using var db = SingleEntityDbContext.Create(collection, ConfigureConverterModel);
+        var updated = db.Entities.ExecuteUpdate(s => s.SetProperty(o => o.Quantity, 99));
+        Assert.Equal(2, updated);
+
+        // The constant must be serialized through the converter-aware property path, so it persists
+        // as a BSON string ("99"), not a raw int — matching how SaveChanges writes the property.
+        var raw = collection.Database
+            .GetCollection<BsonDocument>(collection.CollectionNamespace.CollectionName)
+            .Find(FilterDefinition<BsonDocument>.Empty).ToList();
+        Assert.Equal(2, raw.Count);
+        Assert.All(raw, d => Assert.Equal(BsonType.String, d["Quantity"].BsonType));
+        Assert.All(raw, d => Assert.Equal("99", d["Quantity"].AsString));
+
+        // And it round-trips back through EF as the original CLR int.
+        Assert.All(db.Entities.ToList(), o => Assert.Equal(99, o.Quantity));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteUpdate_logs_ExecutedBulkUpdate_event_with_count(bool async)
+    {
+        var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
+        var collection = database.CreateCollection<Order>(nameof(ExecuteUpdate_logs_ExecutedBulkUpdate_event_with_count), async);
+
+        using (var seedDb = SingleEntityDbContext.Create(collection, ConfigureModel))
+        {
+            seedDb.AddRange(
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 10 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 20 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "closed", Quantity = 30 });
+            seedDb.SaveChanges();
+        }
+
+        using var db = SingleEntityDbContext.Create(collection, loggerFactory, ConfigureModel);
+
+        var updated = async
+            ? await db.Entities.Where(o => o.Status == "open")
+                .ExecuteUpdateAsync(s => s.SetProperty(o => o.Status, "shipped"))
+            : db.Entities.Where(o => o.Status == "open")
+                .ExecuteUpdate(s => s.SetProperty(o => o.Status, "shipped"));
+
+        Assert.Equal(2, updated);
+
+        var executingMessage = spyLogger.GetLogMessageByEventId(MongoEventId.ExecutingBulkUpdate);
+        Assert.Contains("Executing Bulk Update", executingMessage);
+        Assert.Contains($"Collection='{collection.CollectionNamespace}'", executingMessage);
+
+        var executedMessage = spyLogger.GetLogMessageByEventId(MongoEventId.ExecutedBulkUpdate);
+        Assert.Contains("Executed Bulk Update", executedMessage);
+        Assert.Contains($"Collection='{collection.CollectionNamespace}'", executedMessage);
+        Assert.Contains("Modified=2", executedMessage);
+    }
+
+    [Fact]
+    public void ExecuteUpdate_two_phase_empty_target_returns_zero()
+    {
+        using var db = CreateSeededContext();
+
+        // Two-phase phase 1 finds no targets, so phase 2 is skipped and nothing is written.
+        var updated = db.Entities.Where(o => o.Status == "nonexistent").OrderBy(o => o.Quantity).Take(5)
+            .ExecuteUpdate(s => s.SetProperty(o => o.Status, "x"));
+
+        Assert.Equal(0, updated);
+        Assert.Equal(0, db.Entities.Count(o => o.Status == "x"));
+    }
+
+    [Fact]
+    public void ExecuteUpdate_two_phase_returns_matched_count_even_when_values_already_match()
+    {
+        using var db = CreateSeededContext();
+
+        // Two-phase (OrderBy + Take) targeting the two "open" docs and setting Status to its existing value:
+        // the server reports ModifiedCount 0, but ExecuteUpdate must still return the matched-row count (2)
+        // through the { _id: { $in: ... } } UpdateMany path, matching EF Core's contract.
+        var updated = db.Entities.Where(o => o.Status == "open").OrderBy(o => o.Quantity).Take(2)
+            .ExecuteUpdate(s => s.SetProperty(o => o.Status, "open"));
+
+        Assert.Equal(2, updated);
+    }
+
+    [Fact]
+    public void ExecuteUpdate_with_Where_and_Skip_Take_scopes_to_window()
+    {
+        using var db = CreateSeededContext();
+
+        // "open" docs are Quantity 10 and 20; Skip(1).Take(1) over ascending Quantity targets only the 20.
+        var updated = db.Entities.Where(o => o.Status == "open").OrderBy(o => o.Quantity).Skip(1).Take(1)
+            .ExecuteUpdate(s => s.SetProperty(o => o.Status, "windowed"));
+
+        Assert.Equal(1, updated);
+        Assert.Equal(1, db.Entities.Count(o => o.Status == "windowed"));
+        Assert.Contains(db.Entities.ToList(), o => o.Status == "windowed" && o.Quantity == 20);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteUpdate_two_phase_logs_ExecutingBulkUpdate_with_target_count(bool async)
+    {
+        var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
+        var collection = database.CreateCollection<Order>(
+            nameof(ExecuteUpdate_two_phase_logs_ExecutingBulkUpdate_with_target_count), async);
+
+        using (var seedDb = SingleEntityDbContext.Create(collection, ConfigureModel))
+        {
+            seedDb.AddRange(
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 10 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "open", Quantity = 20 },
+                new Order { _id = ObjectId.GenerateNewId(), Status = "closed", Quantity = 30 });
+            seedDb.SaveChanges();
+        }
+
+        using var db = SingleEntityDbContext.Create(collection, loggerFactory, ConfigureModel);
+
+        // Two-phase path (OrderBy + Take), exercised both sync and async.
+        var updated = async
+            ? await db.Entities.OrderBy(o => o.Quantity).Take(2)
+                .ExecuteUpdateAsync(s => s.SetProperty(o => o.Status, "archived"))
+            : db.Entities.OrderBy(o => o.Quantity).Take(2)
+                .ExecuteUpdate(s => s.SetProperty(o => o.Status, "archived"));
+
+        Assert.Equal(2, updated);
+
+        var executingMessage = spyLogger.GetLogMessageByEventId(MongoEventId.ExecutingBulkUpdate);
+        Assert.Contains("Executing Bulk Update", executingMessage);
+        Assert.Contains($"Collection='{collection.CollectionNamespace}'", executingMessage);
+        Assert.Contains("two-phase", executingMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("2 target(s)", executingMessage);
+    }
+}
+
+#endif

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/MongoComplianceTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/MongoComplianceTest.cs
@@ -115,11 +115,21 @@ public class MongoComplianceTest : ComplianceTestBase
         typeof(AdHocMiscellaneousQueryTestBase),
         typeof(AdHocNavigationsQueryTestBase),
         typeof(AdHocQueryFiltersQueryTestBase),
+        // Bulk ExecuteUpdate/ExecuteDelete ARE supported (EF9+), but only for single-collection,
+        // Where-scoped queries with scalar setters. These EF conformance suites target owned-collection,
+        // table-sharing, cross-collection/navigation, and join scenarios outside that supported subset,
+        // so they remain ignored here; behavioral coverage lives in
+        // FunctionalTests/Query/ExecuteDeleteTests.cs and ExecuteUpdateTests.cs.
         typeof(Microsoft.EntityFrameworkCore.BulkUpdates.BulkUpdatesTestBase<>),
         typeof(Microsoft.EntityFrameworkCore.BulkUpdates.FiltersInheritanceBulkUpdatesTestBase<>),
         typeof(Microsoft.EntityFrameworkCore.BulkUpdates.InheritanceBulkUpdatesTestBase<>),
         typeof(Microsoft.EntityFrameworkCore.BulkUpdates.NonSharedModelBulkUpdatesTestBase),
-        typeof(Microsoft.EntityFrameworkCore.BulkUpdates.NorthwindBulkUpdatesTestBase<>),
+        // NorthwindBulkUpdatesTestBase is now implemented by NorthwindBulkUpdatesMongoTest: the supported
+        // single-collection Where-scoped scalar cases, as well as OrderBy/Skip/Take/Distinct-scoped cases
+        // (executed via the two-phase _id-projection path), call base and pass; everything outside that
+        // subset (joins, set ops, GroupBy, SelectMany, navigations, non-entity projections,
+        // multiple-collection updates) is not skipped there — each runs and asserts its actual failure
+        // mode (translation failure or cross-DbSet rejection), tagged with a // Fails: <reason> comment.
         typeof(JsonQueryTestBase<>),
         typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.ComplexTypeTestBase),
         typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.InheritanceTestBase),
@@ -136,6 +146,10 @@ public class MongoComplianceTest : ComplianceTestBase
 
 #if EF9
         // Test bases that existed only in EF9.
+        // Bulk ExecuteUpdate/ExecuteDelete ARE supported (EF9+), but only for single-collection,
+        // Where-scoped queries with scalar setters. This complex-type conformance suite targets
+        // scenarios outside that supported subset, so it remains ignored here; behavioral coverage
+        // lives in FunctionalTests/Query/ExecuteDeleteTests.cs and ExecuteUpdateTests.cs.
         typeof(Microsoft.EntityFrameworkCore.BulkUpdates.ComplexTypeBulkUpdatesTestBase<>),
 #endif
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindBulkUpdatesMongoFixture.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindBulkUpdatesMongoFixture.cs
@@ -1,0 +1,130 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ExecuteUpdate / ExecuteDelete bulk operations are EF9+ only.
+#if !EF8
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.BulkUpdates;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;
+using MongoDB.EntityFrameworkCore.Storage;
+
+namespace MongoDB.EntityFrameworkCore.SpecificationTests.Query;
+
+public class NorthwindBulkUpdatesMongoFixture<TModelCustomizer> : NorthwindBulkUpdatesFixture<TModelCustomizer>
+    where TModelCustomizer : ITestModelCustomizer, new()
+{
+    protected override string StoreName { get; } = TestDatabaseNamer.GetUniqueDatabaseName("NorthwindBulkUpdates");
+
+    private ITestStoreFactory? _testStoreFactory;
+
+    protected override ITestStoreFactory TestStoreFactory
+        => _testStoreFactory!;
+
+    public TestServer TestServer { get; private set; }
+
+    public override async Task InitializeAsync()
+    {
+        TestServer = await TestServer.GetOrInitializeTestServerAsync(MongoCondition.None);
+        _testStoreFactory = new MongoTestStoreFactory(TestServer);
+
+        await base.InitializeAsync();
+    }
+
+    protected override bool UsePooling
+        => false;
+
+    public TestMqlLoggerFactory TestMqlLoggerFactory
+        => (TestMqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
+
+    protected override bool ShouldLogCategory(string logCategory)
+        => logCategory == DbLoggerCategory.Query.Name;
+
+    // EF's BulkUpdatesAsserter wraps every AssertDelete/AssertUpdate in a transaction that is rolled
+    // back, so the shared Northwind seed is left unchanged across the repeated (sync + async) runs.
+    // The transaction is begun on one context and the bulk operation is executed on a *second*
+    // context; this hook enlists that second context in the same MongoDB session so DeleteMany /
+    // UpdateMany participate in — and are rolled back with — the outer transaction. Both contexts
+    // are built against the shared TestServer.Client, so the session handle is valid across them
+    // (CurrentTransaction's internal setter is reachable here via InternalsVisibleTo). The bulk
+    // executor reads the session from Database.CurrentTransaction (see PrepareBulk in
+    // MongoShapedQueryCompilingExpressionVisitor).
+    //
+    // NOTE: this requires a transaction-capable deployment (replica set / mongos). Against a
+    // standalone mongod the BeginTransactionAsync in the asserter will throw, and these tests fail
+    // at setup rather than asserting anything meaningful.
+    public override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+        => ((MongoTransactionManager)facade.GetService<IDbContextTransactionManager>()).CurrentTransaction = transaction;
+
+    protected override Task SeedAsync(NorthwindContext context)
+    {
+        AddEntities(context);
+
+        return context.SaveChangesAsync();
+    }
+
+    private static void AddEntities(NorthwindContext context)
+    {
+        context.Set<Customer>().AddRange(NorthwindData.CreateCustomers());
+        context.Set<Employee>().AddRange(NorthwindData.CreateEmployees());
+
+        var orders = NorthwindData.CreateOrders();
+        foreach (var order in orders)
+        {
+            if (order.OrderDate != null)
+            {
+                // Force the DateTime to be UTC since Mongo will otherwise convert from local to UTC on insertion
+                var o = order.OrderDate.Value;
+                order.OrderDate = new DateTime(o.Year, o.Month, o.Day, o.Hour, o.Minute, o.Second, o.Millisecond, DateTimeKind.Utc);
+            }
+        }
+
+        context.Set<Order>().AddRange(orders);
+
+        context.Set<Product>().AddRange(NorthwindData.CreateProducts());
+        context.Set<OrderDetail>().AddRange(NorthwindData.CreateOrderDetails());
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<Customer>().ToCollection("Customers");
+        modelBuilder.Entity<Employee>().ToCollection("Employees");
+        modelBuilder.Entity<Order>().ToCollection("Orders");
+        modelBuilder.Entity<OrderDetail>().ToCollection("OrderDetails");
+        modelBuilder.Entity<Product>().ToCollection("Products");
+
+        modelBuilder.Entity<CustomerQuery>().ToCollection("Customers");
+        modelBuilder.Entity<OrderQuery>().ToCollection("Orders");
+        modelBuilder.Entity<ProductQuery>().ToCollection("Products");
+        modelBuilder.Entity<ProductView>(b =>
+        {
+            b.Property(e => e.ProductID).HasElementName("_id");
+            b.ToCollection("Products");
+        });
+    }
+}
+
+#endif

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindBulkUpdatesMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindBulkUpdatesMongoTest.cs
@@ -1,0 +1,444 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ExecuteUpdate / ExecuteDelete bulk operations are EF9+ only.
+#if !EF8
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.BulkUpdates;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MongoDB.EntityFrameworkCore.SpecificationTests.Query;
+
+// Conformance coverage for EF Core's bulk-update spec suite, scoped to the subset the MongoDB
+// provider supports: a single collection, scoped by Where, with constant / parameter /
+// self-referencing scalar setters (see README "What is supported" and EF-107).
+//
+// Supported cases call base, which asserts the affected-document count and the before/after
+// document state. Bulk operations emit Executing/ExecutedBulkUpdate|Delete diagnostics events
+// rather than ExecutedMqlQuery, so there is no MQL baseline to pin via AssertMql here (unlike the
+// Northwind *query* suites). Ordering/paging/Distinct-scoped bulk operations are supported via the
+// two-phase (_id-projection) execution path and call base. Per the suite convention (see
+// docs/failing-spec-tests.md) the remaining out-of-subset cases (joins, set operations, GroupBy,
+// SelectMany, navigations, non-entity projections, multiple-collection updates) are not skipped:
+// they run and assert the current failure mode (translation failure, cross-DbSet rejection, or a
+// non-translation exception), tagged with a // Fails: <reason> <ticket> comment. Behavioral
+// coverage for the supported subset also lives in FunctionalTests/Query/ExecuteUpdateTests.cs and
+// ExecuteDeleteTests.cs.
+public class NorthwindBulkUpdatesMongoTest : NorthwindBulkUpdatesTestBase<NorthwindBulkUpdatesMongoFixture<NoopModelCustomizer>>
+{
+    public NorthwindBulkUpdatesMongoTest(
+        NorthwindBulkUpdatesMongoFixture<NoopModelCustomizer> fixture,
+        ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+    // ---- Supported: single-collection, Where-scoped scalar setters ----
+    public override Task Delete_Where(bool async)
+        => base.Delete_Where(async);
+
+    public override Task Delete_Where_TagWith(bool async)
+        => base.Delete_Where_TagWith(async);
+
+    public override Task Delete_Where_parameter(bool async)
+        => base.Delete_Where_parameter(async);
+
+    public override Task Update_Where_multiple_set(bool async)
+        => base.Update_Where_multiple_set(async);
+
+    public override Task Update_Where_parameter_set_constant(bool async)
+        => base.Update_Where_parameter_set_constant(async);
+
+    public override Task Update_Where_set_constant(bool async)
+        => base.Update_Where_set_constant(async);
+
+    public override Task Update_Where_set_constant_TagWith(bool async)
+        => base.Update_Where_set_constant_TagWith(async);
+
+#if EF10
+    public override Task Update_Where_set_constant_via_lambda(bool async)
+        => base.Update_Where_set_constant_via_lambda(async);
+#endif
+
+    public override Task Update_Where_set_null(bool async)
+        => base.Update_Where_set_null(async);
+
+    public override Task Update_Where_set_parameter(bool async)
+        => base.Update_Where_set_parameter(async);
+
+    public override Task Update_Where_set_parameter_from_closure_array(bool async)
+        => base.Update_Where_set_parameter_from_closure_array(async);
+
+    public override Task Update_Where_set_parameter_from_inline_list(bool async)
+        => base.Update_Where_set_parameter_from_inline_list(async);
+
+    public override Task Update_Where_set_parameter_from_multilevel_property_access(bool async)
+        => base.Update_Where_set_parameter_from_multilevel_property_access(async);
+
+    public override Task Update_Where_set_property_plus_constant(bool async)
+        => base.Update_Where_set_property_plus_constant(async);
+
+    public override Task Update_Where_set_property_plus_parameter(bool async)
+        => base.Update_Where_set_property_plus_parameter(async);
+
+    public override Task Update_Where_set_property_plus_property(bool async)
+        => base.Update_Where_set_property_plus_property(async);
+
+    // ---- Out-of-subset shapes: run and assert the current failure mode (see // Fails: tags) ----
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; set operations unsupported EF-X016
+    public override Task Delete_Concat(bool async)
+        => AssertTranslationFailed(() => base.Delete_Concat(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; set operations unsupported EF-X016
+    public override Task Delete_Except(bool async)
+        => AssertTranslationFailed(() => base.Delete_Except(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; GroupBy unsupported EF-X016
+    // Re-declares [ConditionalTheory] (without skip) to run past the upstream EF skip ("Issue#28525") so
+    // the provider's rejection is still asserted (the upstream result-correctness bug never applies — we
+    // throw first). The inherited [MemberData] still supplies the async data; re-declaring it here would
+    // duplicate the test-case IDs, so xUnit1003 (which only sees method-level data) is suppressed.
+#pragma warning disable xUnit1003
+    [ConditionalTheory]
+    public override Task Delete_GroupBy_Where_Select(bool async)
+        => AssertTranslationFailed(() => base.Delete_GroupBy_Where_Select(async));
+#pragma warning restore xUnit1003
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; GroupBy unsupported EF-X016
+    // Re-declares [ConditionalTheory] (without skip) to run past the upstream EF skip ("Issue#26753");
+    // the inherited [MemberData] supplies the async data, so xUnit1003 is suppressed (see above).
+#pragma warning disable xUnit1003
+    [ConditionalTheory]
+    public override Task Delete_GroupBy_Where_Select_2(bool async)
+        => AssertTranslationFailed(() => base.Delete_GroupBy_Where_Select_2(async));
+#pragma warning restore xUnit1003
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; set operations unsupported EF-X016
+    public override Task Delete_Intersect(bool async)
+        => AssertTranslationFailed(() => base.Delete_Intersect(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; SelectMany unsupported EF-X016
+    public override Task Delete_SelectMany(bool async)
+        => AssertTranslationFailed(() => base.Delete_SelectMany(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; SelectMany unsupported EF-X016
+    public override Task Delete_SelectMany_subquery(bool async)
+        => AssertTranslationFailed(() => base.Delete_SelectMany_subquery(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; set operations unsupported EF-X016
+    public override Task Delete_Union(bool async)
+        => AssertTranslationFailed(() => base.Delete_Union(async));
+
+    public override Task Delete_Where_Distinct(bool async)
+        => base.Delete_Where_Distinct(async);
+
+    public override Task Delete_Where_OrderBy(bool async)
+        => base.Delete_Where_OrderBy(async);
+
+    public override Task Delete_Where_OrderBy_Skip(bool async)
+        => base.Delete_Where_OrderBy_Skip(async);
+
+    public override Task Delete_Where_OrderBy_Skip_Take(bool async)
+        => base.Delete_Where_OrderBy_Skip_Take(async);
+
+    public override Task Delete_Where_OrderBy_Take(bool async)
+        => base.Delete_Where_OrderBy_Take(async);
+
+    public override Task Delete_Where_Skip(bool async)
+        => base.Delete_Where_Skip(async);
+
+    public override Task Delete_Where_Skip_Take(bool async)
+        => base.Delete_Where_Skip_Take(async);
+
+    public override Task Delete_Where_Skip_Take_Skip_Take_causing_subquery(bool async)
+        => base.Delete_Where_Skip_Take_Skip_Take_causing_subquery(async);
+
+    public override Task Delete_Where_Take(bool async)
+        => base.Delete_Where_Take(async);
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; cross-document navigation predicates unsupported EF-X016
+    public override Task Delete_Where_optional_navigation_predicate(bool async)
+        => AssertTranslationFailed(() => base.Delete_Where_optional_navigation_predicate(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; GroupBy unsupported EF-X016
+    public override Task Delete_Where_predicate_with_GroupBy_aggregate(bool async)
+        => AssertTranslationFailed(() => base.Delete_Where_predicate_with_GroupBy_aggregate(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; GroupBy unsupported EF-X016
+    public override Task Delete_Where_predicate_with_GroupBy_aggregate_2(bool async)
+        => AssertTranslationFailed(() => base.Delete_Where_predicate_with_GroupBy_aggregate_2(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; cross-document navigation predicates unsupported EF-X016
+    public override Task Delete_Where_using_navigation(bool async)
+        => AssertTranslationFailed(() => base.Delete_Where_using_navigation(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; cross-document navigation predicates unsupported EF-X016
+    public override Task Delete_Where_using_navigation_2(bool async)
+        => AssertTranslationFailed(() => base.Delete_Where_using_navigation_2(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; non-entity projection sources unsupported EF-X016
+    public override Task Delete_non_entity_projection(bool async)
+        => AssertTranslationFailed(() => base.Delete_non_entity_projection(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; non-entity projection sources unsupported EF-X016
+    public override Task Delete_non_entity_projection_2(bool async)
+        => AssertTranslationFailed(() => base.Delete_non_entity_projection_2(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; non-entity projection sources unsupported EF-X016
+    public override Task Delete_non_entity_projection_3(bool async)
+        => AssertTranslationFailed(() => base.Delete_non_entity_projection_3(async));
+
+#if EF10
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Delete_with_LeftJoin(bool async)
+        => AssertTranslationFailed(() => base.Delete_with_LeftJoin(async));
+#endif
+
+#if EF10
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Delete_with_LeftJoin_via_flattened_GroupJoin(bool async)
+        => AssertTranslationFailed(() => base.Delete_with_LeftJoin_via_flattened_GroupJoin(async));
+#endif
+
+#if EF10
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Delete_with_RightJoin(bool async)
+        => AssertTranslationFailed(() => base.Delete_with_RightJoin(async));
+#endif
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Delete_with_cross_apply(bool async)
+        => AssertTranslationFailed(() => base.Delete_with_cross_apply(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Delete_with_cross_join(bool async)
+        => AssertTranslationFailed(() => base.Delete_with_cross_join(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Delete_with_join(bool async)
+        => AssertTranslationFailed(() => base.Delete_with_join(async));
+
+#if EF9
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Delete_with_left_join(bool async)
+        => AssertTranslationFailed(() => base.Delete_with_left_join(async));
+#endif
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Delete_with_outer_apply(bool async)
+        => AssertTranslationFailed(() => base.Delete_with_outer_apply(async));
+
+    // Fails: Throws a non-translation exception, but still throws EF-X002
+    public override Task Update_Concat_set_constant(bool async)
+        => Assert.ThrowsAnyAsync<Exception>(() => base.Update_Concat_set_constant(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; set operations unsupported EF-X016
+    public override Task Update_Except_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_Except_set_constant(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; set operations unsupported EF-X016
+    public override Task Update_Intersect_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_Intersect_set_constant(async));
+
+    // Fails: Throws a non-translation exception, but still throws EF-X002
+    public override Task Update_Union_set_constant(bool async)
+        => Assert.ThrowsAnyAsync<Exception>(() => base.Update_Union_set_constant(async));
+
+    public override Task Update_Where_Distinct_set_constant(bool async)
+        => base.Update_Where_Distinct_set_constant(async);
+
+    public override Task Update_Where_GroupBy_First_set_constant(bool async)
+        => AssertNoMultiCollectionQuerySupport(() => base.Update_Where_GroupBy_First_set_constant(async));
+
+    // Re-declares [ConditionalTheory] (without skip) to run past the upstream EF skip ("Issue#26753");
+    // the inherited [MemberData] supplies the async data, so xUnit1003 is suppressed (see above).
+#pragma warning disable xUnit1003
+    [ConditionalTheory]
+    public override Task Update_Where_GroupBy_First_set_constant_2(bool async)
+        => AssertNoMultiCollectionQuerySupport(() => base.Update_Where_GroupBy_First_set_constant_2(async));
+#pragma warning restore xUnit1003
+
+    public override Task Update_Where_GroupBy_First_set_constant_3(bool async)
+        => AssertNoMultiCollectionQuerySupport(() => base.Update_Where_GroupBy_First_set_constant_3(async));
+
+    public override Task Update_Where_GroupBy_aggregate_set_constant(bool async)
+        => AssertNoMultiCollectionQuerySupport(() => base.Update_Where_GroupBy_aggregate_set_constant(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_Where_Join_set_property_from_joined_single_result_scalar(bool async)
+        => AssertTranslationFailed(() => base.Update_Where_Join_set_property_from_joined_single_result_scalar(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_Where_Join_set_property_from_joined_single_result_table(bool async)
+        => AssertTranslationFailed(() => base.Update_Where_Join_set_property_from_joined_single_result_table(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_Where_Join_set_property_from_joined_table(bool async)
+        => AssertTranslationFailed(() => base.Update_Where_Join_set_property_from_joined_table(async));
+
+    public override Task Update_Where_OrderBy_Skip_Take_Skip_Take_set_constant(bool async)
+        => base.Update_Where_OrderBy_Skip_Take_Skip_Take_set_constant(async);
+
+    public override Task Update_Where_OrderBy_Skip_Take_set_constant(bool async)
+        => base.Update_Where_OrderBy_Skip_Take_set_constant(async);
+
+    public override Task Update_Where_OrderBy_Skip_set_constant(bool async)
+        => base.Update_Where_OrderBy_Skip_set_constant(async);
+
+    public override Task Update_Where_OrderBy_Take_set_constant(bool async)
+        => base.Update_Where_OrderBy_Take_set_constant(async);
+
+    public override Task Update_Where_OrderBy_set_constant(bool async)
+        => base.Update_Where_OrderBy_set_constant(async);
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; SelectMany unsupported EF-X016
+    public override Task Update_Where_SelectMany_set_null(bool async)
+        => AssertTranslationFailed(() => base.Update_Where_SelectMany_set_null(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; SelectMany unsupported EF-X016
+    public override Task Update_Where_SelectMany_subquery_set_null(bool async)
+        => AssertTranslationFailed(() => base.Update_Where_SelectMany_subquery_set_null(async));
+
+    public override Task Update_Where_Skip_Take_set_constant(bool async)
+        => base.Update_Where_Skip_Take_set_constant(async);
+
+    public override Task Update_Where_Skip_set_constant(bool async)
+        => base.Update_Where_Skip_set_constant(async);
+
+    public override Task Update_Where_Take_set_constant(bool async)
+        => base.Update_Where_Take_set_constant(async);
+
+    public override Task Update_Where_set_constant_using_ef_property(bool async)
+        => base.Update_Where_set_constant_using_ef_property(async);
+
+#if EF10
+    public override Task Update_Where_set_nullable_int_constant_via_discard_lambda(bool async)
+        => base.Update_Where_set_nullable_int_constant_via_discard_lambda(async);
+#endif
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; cross-document navigation predicates unsupported EF-X016
+    public override Task Update_Where_using_navigation_2_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_Where_using_navigation_2_set_constant(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; cross-document navigation predicates unsupported EF-X016
+    public override Task Update_Where_using_navigation_set_null(bool async)
+        => AssertTranslationFailed(() => base.Update_Where_using_navigation_set_null(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; multiple-collection updates unsupported EF-X016
+    public override Task Update_multiple_tables_throws(bool async)
+        => AssertTranslationFailed(() => base.Update_multiple_tables_throws(async));
+
+    public override Task Update_unmapped_property_throws(bool async)
+        => AssertTranslationFailed(() => base.Update_unmapped_property_throws(async));
+
+#if EF10
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_LeftJoin(bool async)
+        => AssertTranslationFailed(() => base.Update_with_LeftJoin(async));
+#endif
+
+#if EF10
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_LeftJoin_via_flattened_GroupJoin(bool async)
+        => AssertTranslationFailed(() => base.Update_with_LeftJoin_via_flattened_GroupJoin(async));
+#endif
+
+#if EF10
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_PK_pushdown_and_join_and_multiple_setters(bool async)
+        => AssertTranslationFailed(() => base.Update_with_PK_pushdown_and_join_and_multiple_setters(async));
+#endif
+
+#if EF10
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_RightJoin(bool async)
+        => AssertTranslationFailed(() => base.Update_with_RightJoin(async));
+#endif
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_cross_apply_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_with_cross_apply_set_constant(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_cross_join_cross_apply_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_with_cross_join_cross_apply_set_constant(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_cross_join_left_join_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_with_cross_join_left_join_set_constant(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_cross_join_outer_apply_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_with_cross_join_outer_apply_set_constant(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_cross_join_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_with_cross_join_set_constant(async));
+
+    public override Task Update_with_invalid_lambda_in_set_property_throws(bool async)
+        => AssertTranslationFailed(() => base.Update_with_invalid_lambda_in_set_property_throws(async));
+
+#if EF9
+    public override Task Update_with_invalid_lambda_throws(bool async)
+        => AssertTranslationFailed(() => base.Update_with_invalid_lambda_throws(async));
+#endif
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_join_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_with_join_set_constant(async));
+
+#if EF9
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_left_join_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_with_left_join_set_constant(async));
+#endif
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_outer_apply_set_constant(bool async)
+        => AssertTranslationFailed(() => base.Update_with_outer_apply_set_constant(async));
+
+    // Fails: ExecuteUpdate/ExecuteDelete source restricted to a Where predicate; joins / correlated subqueries unsupported EF-X016
+    public override Task Update_with_two_inner_joins(bool async)
+        => AssertTranslationFailed(() => base.Update_with_two_inner_joins(async));
+
+    public override Task Update_without_property_to_set_throws(bool async)
+        => AssertTranslationFailed(() => base.Update_without_property_to_set_throws(async));
+
+    // Out-of-subset bulk shapes (and the base *_throws cases) are rejected during translation: the
+    // MongoDB provider surfaces them as an InvalidOperationException whose message reports the LINQ
+    // expression could not be translated.
+    private static async Task AssertTranslationFailed(Func<Task> query)
+        => Assert.Contains(
+            "could not be translated",
+            (await Assert.ThrowsAsync<InvalidOperationException>(query)).Message);
+
+    // Fails: Cross-document navigation access issue EF-216
+    private static async Task AssertNoMultiCollectionQuerySupport(Func<Task> query)
+        => Assert.Contains(
+            "Unsupported cross-DbSet query between",
+            (await Assert.ThrowsAsync<InvalidOperationException>(query)).Message);
+}
+
+#endif

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoNonQueryExpressionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoNonQueryExpressionTests.cs
@@ -1,0 +1,122 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.UnitTests.TestUtilities;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.Expressions;
+
+public static class MongoNonQueryExpressionTests
+{
+    class Product
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+    }
+
+    class NonQueryDbContext : DbContext
+    {
+        public DbSet<Product> Products { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+    }
+
+    [Fact]
+    public static void Delete_node_has_correct_kind_and_empty_setters()
+    {
+        using var db = new NonQueryDbContext();
+        var entityType = db.Model.GetEntityTypes().First();
+        var sourceQuery = new MongoQueryExpression(entityType);
+
+        var actual = new MongoNonQueryExpression(sourceQuery);
+
+        Assert.Equal(MongoNonQueryExpression.OperationKind.Delete, actual.Kind);
+        Assert.Same(sourceQuery, actual.SourceQuery);
+        Assert.Equal(typeof(int), actual.Type);
+        Assert.Empty(actual.Setters);
+    }
+
+    [Fact]
+    public static void Update_node_has_correct_kind_and_setters()
+    {
+        using var db = new NonQueryDbContext();
+        var entityType = db.Model.GetEntityTypes().First();
+        var property = db.GetProperty<Product, decimal>(p => p.Price)!;
+        var sourceQuery = new MongoQueryExpression(entityType);
+        var setters = new List<MongoNonQueryExpression.Setter>
+        {
+            new(property, Expression.Constant(5), false)
+        };
+
+        var actual = new MongoNonQueryExpression(sourceQuery, setters);
+
+        Assert.Equal(MongoNonQueryExpression.OperationKind.Update, actual.Kind);
+        Assert.Same(sourceQuery, actual.SourceQuery);
+        Assert.Single(actual.Setters);
+        Assert.Same(property, actual.Setters[0].Property);
+    }
+
+    [Fact]
+    public static void Delete_marker_defaults_to_SingleCommand_strategy()
+    {
+        using var db = new NonQueryDbContext();
+        var entityType = db.Model.GetEntityTypes().First();
+        var sourceQuery = new MongoQueryExpression(entityType);
+        var node = new MongoNonQueryExpression(sourceQuery);
+        Assert.Equal(MongoNonQueryExpression.BulkStrategy.SingleCommand, node.Strategy);
+    }
+
+    [Fact]
+    public static void Delete_marker_carries_TwoPhase_strategy()
+    {
+        using var db = new NonQueryDbContext();
+        var entityType = db.Model.GetEntityTypes().First();
+        var sourceQuery = new MongoQueryExpression(entityType);
+        var node = new MongoNonQueryExpression(sourceQuery, MongoNonQueryExpression.BulkStrategy.TwoPhase);
+        Assert.Equal(MongoNonQueryExpression.BulkStrategy.TwoPhase, node.Strategy);
+    }
+
+    [Fact]
+    public static void Update_marker_defaults_to_SingleCommand_strategy()
+    {
+        using var db = new NonQueryDbContext();
+        var entityType = db.Model.GetEntityTypes().First();
+        var sourceQuery = new MongoQueryExpression(entityType);
+        var setters = new List<MongoNonQueryExpression.Setter>();
+        var node = new MongoNonQueryExpression(sourceQuery, setters);
+        Assert.Equal(MongoNonQueryExpression.BulkStrategy.SingleCommand, node.Strategy);
+        Assert.Equal(MongoNonQueryExpression.OperationKind.Update, node.Kind);
+    }
+
+    [Fact]
+    public static void Update_marker_carries_TwoPhase_strategy()
+    {
+        using var db = new NonQueryDbContext();
+        var entityType = db.Model.GetEntityTypes().First();
+        var sourceQuery = new MongoQueryExpression(entityType);
+        var setters = new List<MongoNonQueryExpression.Setter>();
+        var node = new MongoNonQueryExpression(sourceQuery, setters, MongoNonQueryExpression.BulkStrategy.TwoPhase);
+        Assert.Equal(MongoNonQueryExpression.BulkStrategy.TwoPhase, node.Strategy);
+        Assert.Equal(MongoNonQueryExpression.OperationKind.Update, node.Kind);
+    }
+}


### PR DESCRIPTION
Simulation of the initial commit of upstream mongodb/mongo-efcore-provider#311, replayed onto its original base commit for AI code review experiments. This reproduces only the *first* commit of that PR (before the two rounds of human review feedback were addressed), so review tooling can be evaluated against the same starting point the original human reviewers saw.

Not intended to be merged.